### PR TITLE
Implement screen wake lock on song lyrics

### DIFF
--- a/frontend/app/songs/[id]/page.tsx
+++ b/frontend/app/songs/[id]/page.tsx
@@ -6,10 +6,12 @@ import { db, type Song } from '@/src/lib/db';
 import BackButton from '@/src/components/BackButton';
 import Link from 'next/link';
 import { useAuth } from '@/src/context/AuthContext';
+import { useWakeLock } from '@/src/hooks/useWakeLock';
 
 export default function SongPage() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
+  useWakeLock(true);
 
   const song = useLiveQuery<Song | undefined>(() => (id ? db.songs.get(id) : undefined), [id]);
 

--- a/frontend/src/hooks/useWakeLock.ts
+++ b/frontend/src/hooks/useWakeLock.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// hook to prevent screen from turning off based on the Wake Lock API
+// code from: https://stackoverflow.com/questions/76539285/problems-trying-to-prevent-sleeping-of-display-on-my-web-app
+export function useWakeLock(enabled: boolean) {
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let mounted = true;
+
+    const acquire = async () => {
+      try {
+        if (!mounted) return;
+        if (!('wakeLock' in navigator)) return;
+        if (document.visibilityState !== 'visible') return;
+        if (wakeLockRef.current && !wakeLockRef.current.released) return;
+
+        wakeLockRef.current = await navigator.wakeLock.request('screen');
+      } catch (err) {
+        console.error('Wake lock request failed:', err);
+      }
+    };
+
+    const release = async () => {
+      try {
+        if (wakeLockRef.current && !wakeLockRef.current.released) {
+          await wakeLockRef.current.release();
+        }
+      } catch {}
+      wakeLockRef.current = null;
+    };
+
+    const onVisibilityChange = async () => {
+      if (document.visibilityState === 'visible') {
+        await acquire();
+      } else {
+        await release();
+      }
+    };
+
+    acquire();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      mounted = false;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      release();
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION
### Description:
Implement screen on all times while on song lyrics page. The screen should not go into sleep-mode or turn off when the user is on this page. 
The PR consists of implementing a custom useWakeLock.ts hook based on the WakeLock API to prevent the phone turning off. Hook is taken from stackoverflow (referred to as a comment in the actual hook file). The hook is used on the songs page, when displaying the song lyrics so that users can sing along to songs without their phones turning off.

### Tasks:
- [x] Implement useWakeLock.ts hook
- [x] Refactor songs page to use this hook

### How to test:
The WakeLock API only works on https, making it hard to test locally. When i tested it i had to run: pnpm run dev --hostname 0.0.0.0 --port 3000 --experimental-https. And use my computers IP adress to connect to https.