### PR TITLE
Fix automatic headercolor derived from system preference mode

### DIFF
--- a/frontend/src/context/HeaderColorProvider.tsx
+++ b/frontend/src/context/HeaderColorProvider.tsx
@@ -4,6 +4,7 @@ import { useState, useContext, useEffect, createContext } from 'react';
 import { setCookie, deleteCookie } from 'cookies-next/client';
 import type { HeaderColor } from '../types/theme';
 import { useMounted } from '../hooks/useMounted';
+import { useTheme } from 'next-themes';
 
 type Context = {
   headerColor: HeaderColor | undefined;
@@ -21,11 +22,11 @@ export function HeaderColorProvider({
 }) {
   const mounted = useMounted();
   const [headerOverride, setHeaderOverride] = useState<HeaderColor | undefined>(() => initialColor);
+  const { resolvedTheme } = useTheme();
 
   // Derived header color
-  // const headerColor = headerOverride ?? (resolvedTheme === 'dark' ? 'dark_gray' : 'light_yellow');
-
-  const headerColor = headerOverride ?? initialColor;
+  const headerColor =
+    headerOverride ?? initialColor ?? (resolvedTheme === 'dark' ? 'dark_gray' : 'light_yellow');
 
   // --- Update DOM ---
   useEffect(() => {


### PR DESCRIPTION
Fixed a bug where a line in HeaderColorProvider is commented out that should be in. Now on first mount of site, header color is derived and applied automatically from system preference.  If light mode system preference: implement header color light_yellow. If dark mode sys pref: implement header color dark_gray.

Resolves #105 