### PR TITLE
Create page to display playlists

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-	"conventionalCommits.scopes": ["frontend", "format", "setup", "songform", "colortheme", "pwabanner"]
+	"conventionalCommits.scopes": ["frontend", "format", "setup", "songform", "colortheme", "pwabanner", "playlists"]
 }

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { usePlaylists } from '@/src/hooks/useData';
+import Spinner from '@/src/components/login/Spinner';
+import { toast } from 'react-toastify';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { usePublicPlaylists } from '@/src/hooks/usePublicPlaylists';
+
+export default function PlaylistsPage() {
+  const {
+    data: publicPlaylists,
+    isLoading: loadingPublic,
+    error: publicError,
+  } = usePublicPlaylists();
+
+  const {
+    data: playlistsFromDexie,
+    isLoading: loadingPrivate,
+    error: privateError,
+  } = usePlaylists({
+    maxAgeMins: 5,
+    syncOnMount: true,
+  });
+
+  if (loadingPrivate || loadingPublic) return <Spinner />;
+
+  if (privateError || publicError) {
+    toast.error('Feil i å laste spillelister');
+    return;
+  }
+
+  const privatePlaylists = playlistsFromDexie?.filter((playlist) => !playlist.is_public) ?? [];
+
+  const tabs = [
+    {
+      key: 'public',
+      label: 'Offentlige',
+      data: publicPlaylists,
+      emptyText: 'Ingen offentlige spillelister ennå',
+    },
+    {
+      key: 'private',
+      label: 'Private',
+      data: privatePlaylists,
+      emptyText: 'Du har ingen private spillelister ennå',
+    },
+  ];
+
+  return (
+    <main className="min-h-screen">
+      <div className="max-w-3xl">
+        <h1>Spillelister</h1>
+        <Tabs defaultValue="public">
+          <TabsList className="mt-3">
+            {tabs.map((tab) => (
+              <TabsTrigger
+                key={tab.key}
+                value={tab.key}
+                aria-label={tab.key}
+                className="px-2 py-1.5 rounded-sm transition data-[state=active]:bg-list-bg data-[state=active]:border-0"
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {tabs.map((tab) => (
+            <TabsContent value={tab.key} key={tab.key}>
+              {tab.data.length === 0 ? (
+                <p className="mt-5">{tab.emptyText}</p>
+              ) : (
+                <ul className="flex flex-col divide-y divide-black/10 dark:divide-white/10">
+                  {tab.data.map((playlist) => (
+                    <li
+                      key={playlist.id}
+                      className="py-3 hover:bg-black/5 dark:hover:bg-white/5 transition allow-animation cursor-pointer rounded-xs"
+                    >
+                      <div className="flex flex-col pl-1.5">
+                        <span className="text-base font-medium">
+                          {playlist.title.charAt(0).toUpperCase() + playlist.title.slice(1)}
+                        </span>
+                        <span className="text-xs opacity-60">Spilleliste</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { usePlaylists } from '@/src/hooks/useData';
-import Spinner from '@/src/components/login/Spinner';
+import { db } from '@/src/lib/db'; // your Dexie db instanceimport Spinner from '@/src/components/login/Spinner';
 import { toast } from 'react-toastify';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { usePublicPlaylists } from '@/src/hooks/usePublicPlaylists';
+import { useLiveQuery } from 'dexie-react-hooks';
+import Spinner from '@/src/components/login/Spinner';
 
 export default function PlaylistsPage() {
   const {
@@ -13,18 +14,13 @@ export default function PlaylistsPage() {
     error: publicError,
   } = usePublicPlaylists();
 
-  const {
-    data: playlistsFromDexie,
-    isLoading: loadingPrivate,
-    error: privateError,
-  } = usePlaylists({
-    maxAgeMins: 5,
-    syncOnMount: true,
-  });
+  const playlistsFromDexie = useLiveQuery(() => db.playlists.toArray(), []);
+
+  const loadingPrivate = playlistsFromDexie === undefined;
 
   if (loadingPrivate || loadingPublic) return <Spinner />;
 
-  if (privateError || publicError) {
+  if (publicError) {
     toast.error('Feil i å laste spillelister');
     return;
   }
@@ -47,8 +43,8 @@ export default function PlaylistsPage() {
   ];
 
   return (
-    <main className="min-h-screen">
-      <div className="max-w-3xl">
+    <main className="mb-5  flex flex-col justify-center max-w-5xl mx-auto">
+      <div className="max-w-5xl">
         <h1>Spillelister</h1>
         <Tabs defaultValue="public">
           <TabsList className="mt-3">

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Card({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<'div'> & { size?: 'default' | 'sm' }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        'group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        'group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        'text-base leading-snug font-medium group-data-[size=sm]/card:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn('px-4 group-data-[size=sm]/card:px-3', className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        'flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/frontend/components/ui/separator.tsx
+++ b/frontend/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Separator as SeparatorPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Tabs({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent',
+        'data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground',
+        'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 text-sm outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "cookies-next": "^6.1.1",
         "dexie": "^4.3.0",
         "dexie-react-hooks": "^4.2.0",
+        "fake-indexeddb": "^6.2.5",
         "framer-motion": "^12.35.0",
         "js-cookie": "^3.0.5",
         "localstorage-slim": "^2.7.1",
@@ -34,6 +35,7 @@
         "react-toastify": "^11.0.5",
         "server-only": "^0.0.1",
         "shadcn": "^4.0.8",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -14691,6 +14693,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "dexie": "^4.3.0",
         "dexie-react-hooks": "^4.2.0",
         "fake-indexeddb": "^6.2.5",
+        "fake-indexeddb": "^6.2.5",
         "framer-motion": "^12.35.0",
         "js-cookie": "^3.0.5",
         "localstorage-slim": "^2.7.1",
@@ -35,6 +36,7 @@
         "react-toastify": "^11.0.5",
         "server-only": "^0.0.1",
         "shadcn": "^4.0.8",
+        "sonner": "^2.0.7",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "react-toastify": "^11.0.5",
     "server-only": "^0.0.1",
     "shadcn": "^4.0.8",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "uuid": "^13.0.0"

--- a/frontend/src/components/SongBox.tsx
+++ b/frontend/src/components/SongBox.tsx
@@ -29,7 +29,7 @@ export function SongBox({ song }: SongBoxProps) {
   };
 
   return (
-    <article className="relative rounded-sm outline-1 dark:bg-list-bg outline-[#0000001a] dark:shadow-xs dark:shadow-black hover:shadow-sm active:scale-[0.99] transition">
+    <article className="relative allow-animation rounded-sm outline-1 dark:bg-list-bg outline-[#0000001a] dark:shadow-xs dark:shadow-black hover:shadow-sm active:scale-[0.99] transition">
       <Link href={`/songs/${song.id}`} className="block w-full py-4 pr-10 pl-4 text-left">
         {song.title ?? '(uten tittel)'}
       </Link>

--- a/frontend/src/components/global/Navbar.tsx
+++ b/frontend/src/components/global/Navbar.tsx
@@ -23,7 +23,7 @@ type NavItem = {
 //TODO: links are placeholders, add actual href when the pages are implemented
 const navItems: NavItem[] = [
   { id: 'home', href: '/', Icon: HomeIcon },
-  { id: 'playlists', href: '/playlists', Icon: MusicalNoteIcon },
+  { id: 'songs', href: '/songs', Icon: MusicalNoteIcon },
   { id: 'add', href: '/add', Icon: PlusIcon },
   { id: 'favorites', href: '/favorites', Icon: StarIcon },
   { id: 'settings', href: '/settings', Icon: Cog6ToothIcon },

--- a/frontend/src/components/global/Navbar.tsx
+++ b/frontend/src/components/global/Navbar.tsx
@@ -23,7 +23,7 @@ type NavItem = {
 //TODO: links are placeholders, add actual href when the pages are implemented
 const navItems: NavItem[] = [
   { id: 'home', href: '/', Icon: HomeIcon },
-  { id: 'songs', href: '/songs', Icon: MusicalNoteIcon },
+  { id: 'playlists', href: '/playlists', Icon: MusicalNoteIcon },
   { id: 'add', href: '/add', Icon: PlusIcon },
   { id: 'favorites', href: '/favorites', Icon: StarIcon },
   { id: 'settings', href: '/settings', Icon: Cog6ToothIcon },

--- a/frontend/src/components/playlist/PlaylistForm.tsx
+++ b/frontend/src/components/playlist/PlaylistForm.tsx
@@ -12,6 +12,7 @@ import { Switch } from '@/components/ui/switch';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import MobileTooltip from '../MobileTooltip';
 import SubmitButton from '../SubmitButton';
+import { useWatch } from 'react-hook-form';
 
 type PlaylistFormProps = {
   onSubmit: SubmitHandler<PlaylistInputs>;
@@ -22,7 +23,7 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
     register,
     handleSubmit,
     setValue,
-    watch,
+    control,
     reset,
     formState: { errors },
   } = useForm<PlaylistInputs>({
@@ -39,10 +40,9 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
   const TOAST_ID = 'playlist-toast';
 
   // Watch songsInPlaylist to get instant UI updates
-  const songsInPlaylist = watch('songsInPlaylist');
+  const songsInPlaylist = useWatch({ name: 'songsInPlaylist', control });
   // Watch value of public
-  const isPublic = watch('isPublic');
-
+  const isPublic = useWatch({ name: 'isPublic', control });
   const {
     data: songs,
     isLoading,

--- a/frontend/src/hooks/usePublicPlaylists.ts
+++ b/frontend/src/hooks/usePublicPlaylists.ts
@@ -1,0 +1,41 @@
+// implement tanstack query
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Playlist } from '../lib/db';
+
+type State = {
+  data: Playlist[];
+  isLoading: boolean;
+  error: string | null;
+};
+
+export function usePublicPlaylists(): State {
+  const [data, setData] = useState<Playlist[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPlaylists = async () => {
+      try {
+        const res = await fetch('/api/playlists');
+        const json = await res.json();
+
+        if (!res.ok || !json.ok) {
+          throw new Error('Failed to fetch playlists');
+        }
+
+        setData(json.data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPlaylists();
+  }, []);
+
+  return { data, isLoading, error };
+}

--- a/frontend/src/lib/playlists/syncPlaylists.ts
+++ b/frontend/src/lib/playlists/syncPlaylists.ts
@@ -1,4 +1,4 @@
-import { db } from '../db';
+import { db } from '@/src/lib/db';
 import { createClient } from '../supabase/client';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       shadcn:
         specifier: ^4.0.8
         version: 4.0.8(@types/node@20.19.33)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4687,6 +4690,12 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10164,6 +10173,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
Created a page to display playlists.

**What I've done:**
- [x] The page is on /playlists and updated navbar to route here
- [x] Fetch playlists from dexie and filter out so only private playlists remain
- [x] Create hook usePublicPlaylist to fetch (public) playlists from supabase
- [x] Implement tabs from shadcn to view public and private playlists separately

**How to test:**
- See it on /playlists. Add songs on /make_playlist, both private and public. Verify they appear on /playlists.

Will later implement E2E testing on flow of creating playlist and viewing it, but waiting in later sprint when functionality is final.

Resolves #63 