### PR TITLE
Fix re rendering of form

### DIFF
--- a/frontend/app/add/page.tsx
+++ b/frontend/app/add/page.tsx
@@ -7,10 +7,10 @@ import { createClient } from '@/src/lib/supabase/client';
 import { syncService } from '@/src/lib/syncService';
 
 export default function AddSongPage() {
-  const { isAdmin, isLoading } = useAuth();
+  const { isAdmin } = useAuth();
   const supabase = createClient();
 
-  if (isLoading || isAdmin === null) {
+  if (isAdmin === null) {
     return <div>Henter skjema...</div>;
   }
 

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -7,7 +7,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { useSearchParams } from 'next/navigation';
 
 export default function Admin() {
-  const { user, isLoading: authLoading } = useAuth();
+  const { user } = useAuth();
   const router = useRouter();
   const params = useSearchParams();
   const error = params.get('error');
@@ -18,8 +18,7 @@ export default function Admin() {
     }
   }, [user, router]);
 
-  if (authLoading || user)
-    return <Spinner message={user ? 'Omdirigerer til admin' : 'Laster inn'} />;
+  if (user) return <Spinner message={user ? 'Omdirigerer til admin' : 'Laster inn'} />;
 
   if (error === 'invalid-user') {
     return (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -37,17 +37,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     : undefined;
 
   return (
-    <AuthProvider>
-      <html lang="en" suppressHydrationWarning data-theme={headerColor}>
-        <head>
-          <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-          <link rel="manifest" href="/manifest.webmanifest" />
-          <link rel="icon" href="/favicon.ico" sizes="32x32" />
-          <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
-        </head>
-        <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
-        >
+    <html lang="en" suppressHydrationWarning data-theme={headerColor}>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <link rel="manifest" href="/manifest.webmanifest" />
+        <link rel="icon" href="/favicon.ico" sizes="32x32" />
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+      </head>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}>
+        <AuthProvider>
           <GlobalSync />
           <TooltipProvider>
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem enableColorScheme>
@@ -63,8 +61,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               </HeaderColorProvider>
             </ThemeProvider>
           </TooltipProvider>
-        </body>
-      </html>
-    </AuthProvider>
+        </AuthProvider>
+      </body>
+    </html>
   );
 }

--- a/frontend/app/make_playlist/page.tsx
+++ b/frontend/app/make_playlist/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useAuth } from '@/src/context/AuthContext';
 import { SubmitHandler } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import PlaylistForm from '@/src/components/playlist/PlaylistForm';
@@ -8,12 +7,6 @@ import { PlaylistInputs } from '@/src/types/playlistInputs';
 import { savePlaylist } from '@/src/lib/playlists/savePlaylists';
 
 export default function MakePlaylistPage() {
-  const { isLoading } = useAuth();
-
-  if (isLoading) {
-    return <p className="text-center mt-10">Laster...</p>;
-  }
-
   const handleFormSubmit: SubmitHandler<PlaylistInputs> = async (data) => {
     try {
       // Prevent creating empty playlists

--- a/frontend/app/songs/[id]/edit/page.tsx
+++ b/frontend/app/songs/[id]/edit/page.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 export default function EditSongPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const { isAdmin, isLoading } = useAuth();
+  const { isAdmin } = useAuth();
   const [isDeletingSong, setIsDeletingSong] = useState(false);
 
   const song = useLiveQuery<Song | undefined>(() => (id ? db.songs.get(id) : undefined), [id]);
@@ -30,10 +30,6 @@ export default function EditSongPage() {
 
     return resolvedTags;
   }, [id]);
-
-  if (isLoading) {
-    return <p className="text-center mt-10">Laster...</p>;
-  }
 
   if (!isAdmin) {
     return <p className="text-center mt-10">Ingen tilgang.</p>;

--- a/frontend/src/components/SongForm.tsx
+++ b/frontend/src/components/SongForm.tsx
@@ -214,12 +214,3 @@ export default function SongForm({
     </>
   );
 }
-
-function getLinkType(url: string) {
-  if (!url) return null;
-
-  if (url.includes('spotify.com')) return 'spotify';
-  if (url.includes('youtube.com') || url.includes('youtu.be')) return 'youtube';
-
-  return null;
-}

--- a/frontend/src/components/SongForm.tsx
+++ b/frontend/src/components/SongForm.tsx
@@ -11,6 +11,7 @@ type Tag = {
   name: string;
 };
 import SubmitButton from './SubmitButton';
+import { useRouter } from 'next/navigation';
 
 type Inputs = {
   title: string;
@@ -57,6 +58,8 @@ export default function SongForm({
     },
   });
 
+  const router = useRouter();
+
   useEffect(() => {
     if (initialValues) {
       reset({
@@ -84,6 +87,7 @@ export default function SongForm({
       await onSubmit(payload);
 
       toast.success(toastSuccessMessage);
+      router.push('/');
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : 'Noe gikk galt');

--- a/frontend/src/components/SongForm.tsx
+++ b/frontend/src/components/SongForm.tsx
@@ -11,6 +11,7 @@ type Tag = {
   name: string;
 };
 import SubmitButton from './SubmitButton';
+import { usePathname } from 'next/navigation';
 
 type Inputs = {
   title: string;
@@ -30,6 +31,8 @@ type SongFormProps = {
   toastSuccessMessage?: string;
 };
 
+const STORAGE_KEY = 'songForm';
+
 export default function SongForm({
   heading,
   submitLabel,
@@ -38,6 +41,21 @@ export default function SongForm({
   onSubmit,
   toastSuccessMessage = 'Lagret',
 }: SongFormProps) {
+  const saved = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+  const pathname = usePathname();
+
+  const defaultValues: Inputs = saved
+    ? JSON.parse(saved)
+    : {
+        title: '',
+        melody: '',
+        author: '',
+        lyrics: '',
+        spotify_youtube: '',
+        tags: [],
+        ...initialValues,
+      };
+
   const {
     register,
     handleSubmit,
@@ -46,16 +64,31 @@ export default function SongForm({
     reset,
     setValue,
   } = useForm<Inputs>({
-    defaultValues: {
-      title: '',
-      melody: '',
-      author: '',
-      lyrics: '',
-      spotify_youtube: '',
-      tags: [],
-      ...initialValues,
-    },
+    defaultValues,
   });
+
+  const values = useWatch({ control });
+
+  // Persist form to localStorage on every change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+  }, [values]);
+
+  // Clear localStorage on page reload or navigation away
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      localStorage.removeItem(STORAGE_KEY);
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      // Only clear if navigating to a different route
+      if (typeof window !== 'undefined' && pathname !== window.location.pathname) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [pathname]);
 
   useEffect(() => {
     if (initialValues) {
@@ -72,7 +105,6 @@ export default function SongForm({
 
   const lyricsValue = useWatch({ control, name: 'lyrics' }) || '';
   const selectedTags = useWatch({ control, name: 'tags' }) ?? [];
-  // const notify = () => toast('Sang lagt inn');
 
   const handleFormSubmit: SubmitHandler<Inputs> = async (data) => {
     try {
@@ -84,6 +116,19 @@ export default function SongForm({
       await onSubmit(payload);
 
       toast.success(toastSuccessMessage);
+
+      // Reset form to default values
+      reset({
+        title: '',
+        melody: '',
+        author: '',
+        lyrics: '',
+        spotify_youtube: '',
+        tags: [],
+      });
+
+      // Remove saved form from localStorage
+      localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : 'Noe gikk galt');

--- a/frontend/src/components/SongForm.tsx
+++ b/frontend/src/components/SongForm.tsx
@@ -11,7 +11,6 @@ type Tag = {
   name: string;
 };
 import SubmitButton from './SubmitButton';
-import { usePathname } from 'next/navigation';
 
 type Inputs = {
   title: string;
@@ -31,8 +30,6 @@ type SongFormProps = {
   toastSuccessMessage?: string;
 };
 
-const STORAGE_KEY = 'songForm';
-
 export default function SongForm({
   heading,
   submitLabel,
@@ -41,21 +38,6 @@ export default function SongForm({
   onSubmit,
   toastSuccessMessage = 'Lagret',
 }: SongFormProps) {
-  const saved = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
-  const pathname = usePathname();
-
-  const defaultValues: Inputs = saved
-    ? JSON.parse(saved)
-    : {
-        title: '',
-        melody: '',
-        author: '',
-        lyrics: '',
-        spotify_youtube: '',
-        tags: [],
-        ...initialValues,
-      };
-
   const {
     register,
     handleSubmit,
@@ -64,31 +46,16 @@ export default function SongForm({
     reset,
     setValue,
   } = useForm<Inputs>({
-    defaultValues,
+    defaultValues: {
+      title: '',
+      melody: '',
+      author: '',
+      lyrics: '',
+      spotify_youtube: '',
+      tags: [],
+      ...initialValues,
+    },
   });
-
-  const values = useWatch({ control });
-
-  // Persist form to localStorage on every change
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
-  }, [values]);
-
-  // Clear localStorage on page reload or navigation away
-  useEffect(() => {
-    const handleBeforeUnload = () => {
-      localStorage.removeItem(STORAGE_KEY);
-    };
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      // Only clear if navigating to a different route
-      if (typeof window !== 'undefined' && pathname !== window.location.pathname) {
-        localStorage.removeItem(STORAGE_KEY);
-      }
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [pathname]);
 
   useEffect(() => {
     if (initialValues) {
@@ -105,6 +72,7 @@ export default function SongForm({
 
   const lyricsValue = useWatch({ control, name: 'lyrics' }) || '';
   const selectedTags = useWatch({ control, name: 'tags' }) ?? [];
+  // const notify = () => toast('Sang lagt inn');
 
   const handleFormSubmit: SubmitHandler<Inputs> = async (data) => {
     try {
@@ -116,19 +84,6 @@ export default function SongForm({
       await onSubmit(payload);
 
       toast.success(toastSuccessMessage);
-
-      // Reset form to default values
-      reset({
-        title: '',
-        melody: '',
-        author: '',
-        lyrics: '',
-        spotify_youtube: '',
-        tags: [],
-      });
-
-      // Remove saved form from localStorage
-      localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : 'Noe gikk galt');

--- a/frontend/src/components/admin/AdminContent.tsx
+++ b/frontend/src/components/admin/AdminContent.tsx
@@ -7,9 +7,9 @@ import { useAuth } from '@/src/context/AuthContext';
 
 export default function AdminContent() {
   const { data: suggestions, isLoading: suggestionsLoading } = useSongSuggestions();
-  const { user, isLoading: authLoading } = useAuth();
+  const { user } = useAuth();
 
-  if (authLoading || suggestionsLoading) {
+  if (suggestionsLoading) {
     return <Spinner message="Laster inn admin" />;
   }
 

--- a/frontend/src/components/pages/LoginPage.tsx
+++ b/frontend/src/components/pages/LoginPage.tsx
@@ -6,9 +6,9 @@ import { useAuth } from '@/src/context/AuthContext';
 import Image from 'next/image';
 
 export default function LoginPage() {
-  const { user, isLoading } = useAuth();
+  const { user } = useAuth();
 
-  if (isLoading || user) {
+  if (user) {
     return <Spinner message="Laster inn" />; // Show spinner while checking or redirecting
   }
 

--- a/frontend/src/components/playlist/PlaylistForm.tsx
+++ b/frontend/src/components/playlist/PlaylistForm.tsx
@@ -6,19 +6,35 @@ import { PlaylistInputs } from '@/src/types/playlistInputs';
 import SongList from './SongList';
 import { useSongs } from '@/src/hooks/useData';
 import { Song } from '@/src/lib/db';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { Switch } from '@/components/ui/switch';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import MobileTooltip from '../MobileTooltip';
 import SubmitButton from '../SubmitButton';
 import { useWatch } from 'react-hook-form';
+import { usePathname } from 'next/navigation';
 
 type PlaylistFormProps = {
   onSubmit: SubmitHandler<PlaylistInputs>;
 };
 
+const STORAGE_KEY = 'playlistForm';
+
 export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
+  const saved = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+  const pathname = usePathname();
+
+  const defaultValues: PlaylistInputs = saved
+    ? JSON.parse(saved)
+    : {
+        title: '',
+        password: '',
+        songsInPlaylist: [],
+        duration: 604800,
+        isPublic: false,
+      };
+
   const {
     register,
     handleSubmit,
@@ -27,14 +43,31 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
     reset,
     formState: { errors },
   } = useForm<PlaylistInputs>({
-    defaultValues: {
-      title: '',
-      password: '',
-      songsInPlaylist: [],
-      duration: 604800, // Default value for public playlists
-      isPublic: false,
-    },
+    defaultValues,
   });
+
+  const values = useWatch({ control });
+
+  // Persist to localStorage on every change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+  }, [values]);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      localStorage.removeItem(STORAGE_KEY); // Clear on page reload or tab close
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      // Only clear storage if the pathname changed (navigating away)
+      if (typeof window !== 'undefined' && pathname !== window.location.pathname) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [pathname]);
 
   // Track toasts to prevent multiple toasts to show up at the same time
   const TOAST_ID = 'playlist-toast';
@@ -94,7 +127,17 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
 
   const handleFormSubmit: SubmitHandler<PlaylistInputs> = async (data) => {
     await onSubmit(data);
-    reset();
+    // Reset the form to initial default values
+    reset({
+      title: '',
+      password: '',
+      songsInPlaylist: [],
+      duration: 604800,
+      isPublic: false,
+    });
+
+    // Remove saved form from localStorage
+    localStorage.removeItem(STORAGE_KEY);
   };
 
   return (

--- a/frontend/src/components/playlist/PlaylistForm.tsx
+++ b/frontend/src/components/playlist/PlaylistForm.tsx
@@ -13,6 +13,7 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import MobileTooltip from '../MobileTooltip';
 import SubmitButton from '../SubmitButton';
 import { useWatch } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 
 type PlaylistFormProps = {
   onSubmit: SubmitHandler<PlaylistInputs>;
@@ -24,7 +25,6 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
     handleSubmit,
     setValue,
     control,
-    reset,
     formState: { errors },
   } = useForm<PlaylistInputs>({
     defaultValues: {
@@ -35,6 +35,8 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
       isPublic: false,
     },
   });
+
+  const router = useRouter();
 
   // Track toasts to prevent multiple toasts to show up at the same time
   const TOAST_ID = 'playlist-toast';
@@ -94,7 +96,7 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
 
   const handleFormSubmit: SubmitHandler<PlaylistInputs> = async (data) => {
     await onSubmit(data);
-    reset();
+    router.push('/');
   };
 
   return (

--- a/frontend/src/components/playlist/PlaylistForm.tsx
+++ b/frontend/src/components/playlist/PlaylistForm.tsx
@@ -6,35 +6,19 @@ import { PlaylistInputs } from '@/src/types/playlistInputs';
 import SongList from './SongList';
 import { useSongs } from '@/src/hooks/useData';
 import { Song } from '@/src/lib/db';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { Switch } from '@/components/ui/switch';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import MobileTooltip from '../MobileTooltip';
 import SubmitButton from '../SubmitButton';
 import { useWatch } from 'react-hook-form';
-import { usePathname } from 'next/navigation';
 
 type PlaylistFormProps = {
   onSubmit: SubmitHandler<PlaylistInputs>;
 };
 
-const STORAGE_KEY = 'playlistForm';
-
 export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
-  const saved = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
-  const pathname = usePathname();
-
-  const defaultValues: PlaylistInputs = saved
-    ? JSON.parse(saved)
-    : {
-        title: '',
-        password: '',
-        songsInPlaylist: [],
-        duration: 604800,
-        isPublic: false,
-      };
-
   const {
     register,
     handleSubmit,
@@ -43,31 +27,14 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
     reset,
     formState: { errors },
   } = useForm<PlaylistInputs>({
-    defaultValues,
+    defaultValues: {
+      title: '',
+      password: '',
+      songsInPlaylist: [],
+      duration: 604800, // Default value for public playlists
+      isPublic: false,
+    },
   });
-
-  const values = useWatch({ control });
-
-  // Persist to localStorage on every change
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
-  }, [values]);
-
-  useEffect(() => {
-    const handleBeforeUnload = () => {
-      localStorage.removeItem(STORAGE_KEY); // Clear on page reload or tab close
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      // Only clear storage if the pathname changed (navigating away)
-      if (typeof window !== 'undefined' && pathname !== window.location.pathname) {
-        localStorage.removeItem(STORAGE_KEY);
-      }
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [pathname]);
 
   // Track toasts to prevent multiple toasts to show up at the same time
   const TOAST_ID = 'playlist-toast';
@@ -127,17 +94,7 @@ export default function PlaylistForm({ onSubmit }: PlaylistFormProps) {
 
   const handleFormSubmit: SubmitHandler<PlaylistInputs> = async (data) => {
     await onSubmit(data);
-    // Reset the form to initial default values
-    reset({
-      title: '',
-      password: '',
-      songsInPlaylist: [],
-      duration: 604800,
-      isPublic: false,
-    });
-
-    // Remove saved form from localStorage
-    localStorage.removeItem(STORAGE_KEY);
+    reset();
   };
 
   return (

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,7 +5,6 @@ import { AuthProviderInner } from './AuthProviderInner';
 type AuthContextType = {
   user: { name: string; email: string } | null;
   isAdmin: boolean | null;
-  isLoading: boolean;
   logout: () => Promise<void>;
 };
 

--- a/frontend/src/context/AuthProviderInner.tsx
+++ b/frontend/src/context/AuthProviderInner.tsx
@@ -6,7 +6,7 @@ import { AuthContext } from './AuthContext';
 export const AuthProviderInner = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<{ name: string; email: string } | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isInitialized, setIsInitialized] = useState(false);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -49,15 +49,13 @@ export const AuthProviderInner = ({ children }: { children: ReactNode }) => {
         setIsAdmin(false);
       }
 
-      setIsLoading(false);
+      setIsInitialized(true);
     };
 
     updateAuthState();
 
     const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
       if (!isMounted.current) return;
-
-      setIsLoading(true);
 
       if (session?.user) {
         setUser({
@@ -76,7 +74,6 @@ export const AuthProviderInner = ({ children }: { children: ReactNode }) => {
       }
 
       if (!isMounted.current) return;
-      setIsLoading(false);
     });
 
     return () => {
@@ -86,21 +83,21 @@ export const AuthProviderInner = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const logout = async () => {
-    if (!isMounted.current) return;
-    setIsLoading(true);
-
     const supabase = createClient();
     await supabase.auth.signOut();
 
     if (!isMounted.current) return;
     setUser(null);
     setIsAdmin(false);
-    setIsLoading(false);
   };
 
-  return (
-    <AuthContext.Provider value={{ user, isAdmin, isLoading, logout }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  if (!isInitialized) {
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <p>Laster...</p>
+      </div>
+    );
+  }
+
+  return <AuthContext.Provider value={{ user, isAdmin, logout }}>{children}</AuthContext.Provider>;
 };

--- a/frontend/src/tests/components/Login.test.tsx
+++ b/frontend/src/tests/components/Login.test.tsx
@@ -16,18 +16,6 @@ vi.mock('@/components/ui/spinner', () => ({
 vi.mock('@/src/context/AuthContext');
 
 describe('Login component', () => {
-  it('renders Spinner when loading', () => {
-    vi.useFakeTimers();
-
-    (useAuth as unknown as Mock).mockReturnValue({ user: null, isLoading: true });
-    render(<Login />);
-
-    vi.advanceTimersByTime(400);
-    expect(screen.getByText('Laster inn')).toBeInTheDocument();
-
-    vi.useRealTimers();
-  });
-
   it('renders Spinner when user is logged in', () => {
     vi.useFakeTimers();
 

--- a/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
+++ b/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
@@ -56,6 +56,7 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
+  usePathname: () => '/',
 }));
 
 // ---- tests ----

--- a/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
+++ b/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
@@ -26,7 +26,6 @@ vi.mock('react-toastify', () => {
 vi.mock('@/src/hooks/useData', () => ({
   useSongs: () => ({
     data: [{ id: '1', title: 'Song 1', lyrics: '' } as Song],
-    isLoading: false,
     error: null,
   }),
 }));

--- a/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
+++ b/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
@@ -56,7 +56,6 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
-  usePathname: () => '/',
 }));
 
 // ---- tests ----

--- a/frontend/src/tests/context/AuthContext.test.tsx
+++ b/frontend/src/tests/context/AuthContext.test.tsx
@@ -35,7 +35,7 @@ describe('AuthContext', () => {
       const auth = useAuth();
       return (
         <div>
-          {auth.user?.email} / {String(auth.isAdmin)} / {String(auth.isLoading)}
+          {auth.user?.email} / {String(auth.isAdmin)}
         </div>
       );
     }
@@ -45,7 +45,6 @@ describe('AuthContext', () => {
         value={{
           user: { name: 'Test User', email: 'test@example.com' },
           isAdmin: true,
-          isLoading: false,
           logout: vi.fn(),
         }}
       >
@@ -53,6 +52,6 @@ describe('AuthContext', () => {
       </AuthContext.Provider>
     );
 
-    expect(screen.getByText('test@example.com / true / false')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com / true')).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/context/AuthProviderInner.test.tsx
+++ b/frontend/src/tests/context/AuthProviderInner.test.tsx
@@ -22,14 +22,13 @@ vi.mock('@/src/lib/supabase/client', () => ({
 }));
 
 function TestConsumer() {
-  const { user, isAdmin, isLoading, logout } = useAuth();
+  const { user, isAdmin, logout } = useAuth();
 
   return (
     <div>
       <div data-testid="name">{user?.name ?? 'null'}</div>
       <div data-testid="email">{user?.email ?? 'null'}</div>
       <div data-testid="isAdmin">{String(isAdmin)}</div>
-      <div data-testid="isLoading">{String(isLoading)}</div>
       <button onClick={() => void logout()}>Logout</button>
     </div>
   );
@@ -65,11 +64,12 @@ describe('AuthProviderInner', () => {
 
     renderProvider();
 
+    await waitFor(() => expect(screen.queryByText('Laster...')).not.toBeInTheDocument());
+
     await waitFor(() => {
       expect(screen.getByTestId('name').textContent).toBe('null');
       expect(screen.getByTestId('email').textContent).toBe('null');
       expect(screen.getByTestId('isAdmin').textContent).toBe('false');
-      expect(screen.getByTestId('isLoading').textContent).toBe('false');
     });
   });
 
@@ -98,7 +98,6 @@ describe('AuthProviderInner', () => {
       expect(screen.getByTestId('name').textContent).toBe('Jane Doe');
       expect(screen.getByTestId('email').textContent).toBe('user@example.com');
       expect(screen.getByTestId('isAdmin').textContent).toBe('true');
-      expect(screen.getByTestId('isLoading').textContent).toBe('false');
     });
   });
 
@@ -138,7 +137,6 @@ describe('AuthProviderInner', () => {
       expect(screen.getByTestId('name').textContent).toBe('null');
       expect(screen.getByTestId('email').textContent).toBe('null');
       expect(screen.getByTestId('isAdmin').textContent).toBe('false');
-      expect(screen.getByTestId('isLoading').textContent).toBe('false');
     });
   });
 });

--- a/frontend/src/tests/songs/songs_id_edit.test.tsx
+++ b/frontend/src/tests/songs/songs_id_edit.test.tsx
@@ -152,22 +152,9 @@ describe('EditSongPage', () => {
     );
   });
 
-  test('shows loading when auth is loading', () => {
-    mockUseAuth.mockReturnValue({
-      isAdmin: false,
-      isLoading: true,
-    });
-    mockUseLiveQuery.mockReturnValue(undefined);
-
-    render(<EditSongPage />);
-
-    expect(screen.getByText('Laster...')).toBeInTheDocument();
-  });
-
   test('shows access denied when user is not admin', () => {
     mockUseAuth.mockReturnValue({
       isAdmin: false,
-      isLoading: false,
     });
     mockUseLiveQuery.mockReturnValue(undefined);
 
@@ -180,7 +167,6 @@ describe('EditSongPage', () => {
   test('passes existing tags to SongForm initialValues', () => {
     mockUseAuth.mockReturnValue({
       isAdmin: true,
-      isLoading: false,
     });
 
     const song = {
@@ -217,7 +203,6 @@ describe('EditSongPage', () => {
 
     mockUseAuth.mockReturnValue({
       isAdmin: true,
-      isLoading: false,
     });
 
     const song = {


### PR DESCRIPTION
### What's done
- Prevent fields to return to default values when user switches tabs or windows by changing /src/context/AuthProviderInner.tsx to show global loading screen as long as the auth is not initialized
- Re-route to homepage when SongForm and PlaylistForm is submitted
- Updated tests