### PR TITLE
Fix chord bug for song suggestion and add length limit

### DIFF
--- a/frontend/app/admin/(protected)/suggestions/[id]/page.tsx
+++ b/frontend/app/admin/(protected)/suggestions/[id]/page.tsx
@@ -10,10 +10,13 @@ import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Spinner } from '@/components/ui/spinner';
 import { SuggestionActions } from '@/src/components/suggestions/SuggestionActions';
 import Lyrics from '@/src/components/songs/Lyrics';
+import { Switch } from '@/components/ui/switch';
+import { useState } from 'react';
 
 export default function SuggestionPage() {
   const { id } = useParams<{ id: string }>();
   const mounted = useMounted();
+  const [showChords, setShowChords] = useState(false);
 
   const dexieSuggestion = useLiveQuery(() => {
     if (typeof window === 'undefined' || !mounted || !id) {
@@ -31,6 +34,9 @@ export default function SuggestionPage() {
   if (dexieSuggestion === null || !suggestion) {
     return <Spinner message="Oppdaterer data" />;
   }
+
+  const hasChords =
+    suggestion.verses?.some((v) => v.includes('[')) || suggestion.chorus?.includes('[');
 
   return (
     <main className="relative w-full text-center px-4">
@@ -54,8 +60,15 @@ export default function SuggestionPage() {
 
       {suggestion.melody && <p className="opacity-60 mt-1">Melodi: {suggestion.melody}</p>}
 
+      {hasChords && (
+        <div className="flex items-center justify-center gap-2 mt-3">
+          <Switch checked={showChords} onCheckedChange={setShowChords} />
+          <span className="text-sm opacity-60">Vis akkorder</span>
+        </div>
+      )}
+
       <pre className="mt-8 flex justify-center text-center whitespace-pre-wrap">
-        <Lyrics chorus={suggestion.chorus} verses={suggestion.verses} />
+        <Lyrics chorus={suggestion.chorus} verses={suggestion.verses} showChords={showChords} />
       </pre>
 
       {suggestion.author && <p className="opacity-60 mt-1">Skrevet av: {suggestion.author}</p>}

--- a/frontend/src/components/chords/ChordPopover.tsx
+++ b/frontend/src/components/chords/ChordPopover.tsx
@@ -114,6 +114,7 @@ export function ChordPopover({ isOpen, token, onClose, onChordSelect }: ChordPop
           type="text"
           value={customChord}
           placeholder="Egen akkord"
+          maxLength={10}
           onChange={(e) => setCustomChord(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {


### PR DESCRIPTION
### Description on what has been fixed:
- [x] Add length limit to custom chord
- [x] Fix bug where chords are not shown in song-suggestion

The bug was that the chords wouldnt appear on song suggestions but still be inline chords when editing. The chords worked as usual when an admin added songs. The reason why this bug appeared was because showChords state and the toggle was not implemented in the songsuggestion-page and only the "normal" song-page. Therefore the lyrics always had chords but due to the state and the toggle not being present, it never rendered on the song-suggestion page.