### PR TITLE
UI fixes in navbar and searchbar

### DIFF
--- a/frontend/src/components/SearchField.tsx
+++ b/frontend/src/components/SearchField.tsx
@@ -10,9 +10,9 @@ export function SearchField({ value, onChange }: SearchFieldProps) {
     <div className="mb-6">
       <div
         className="
-            flex items-center rounded-xl 
+            flex items-center rounded-lg 
             border border-neutral-300 dark:border-neutral-700
-            bg-white dark:bg-neutral-900
+            bg-transparent dark:bg-input/30
             px-3 py-2 shadow-sm
             focus-within:border-neutral-400 dark:focus-within:border-neutral-500
             hover:border-neutral-400 dark:hover:border-neutral-500
@@ -39,7 +39,7 @@ export function SearchField({ value, onChange }: SearchFieldProps) {
           onChange={(e) => onChange(e.target.value)}
           placeholder="Søk etter sanger..."
           className="
-                w-full bg-transparent text-sm outline-none
+                w-full bg-transparent text-base outline-none
                 text-neutral-900 dark:text-neutral-100
                 placeholder:text-neutral-400 dark:placeholder:text-neutral-500"
         />

--- a/frontend/src/components/global/Navbar.tsx
+++ b/frontend/src/components/global/Navbar.tsx
@@ -17,15 +17,16 @@ import SongOrPlaylistBox from '../SongOrPlaylistBox';
 type NavItem = {
   id: string;
   href: string;
+  label: string;
   Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 };
 
 const navItems: NavItem[] = [
-  { id: 'home', href: '/', Icon: HomeIcon },
-  { id: 'playlists', href: '/playlists', Icon: MusicalNoteIcon },
-  { id: 'add', href: '/add', Icon: PlusIcon },
-  { id: 'favorites', href: '/favorites', Icon: StarIcon },
-  { id: 'settings', href: '/settings', Icon: Cog6ToothIcon },
+  { id: 'home', href: '/', label: 'Hjem', Icon: HomeIcon },
+  { id: 'playlists', href: '/playlists', label: 'Spillelister', Icon: MusicalNoteIcon },
+  { id: 'add', href: '/add', label: 'Opprett', Icon: PlusIcon },
+  { id: 'favorites', href: '/favorites', label: 'Favoritter', Icon: StarIcon },
+  { id: 'settings', href: '/settings', label: 'Innstillinger', Icon: Cog6ToothIcon },
 ];
 
 // Navigation component
@@ -36,9 +37,13 @@ export default function Navbar() {
   const [showSongOrPlaylistBox, setShowSongOrPlaylistBox] = useState(false);
   const songChoice = isAdmin ? 'Publiser sang' : 'Send inn sangforslag';
 
-  const handleAddClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setShowSongOrPlaylistBox((prev) => !prev);
+  const handleNavClick = (e: React.MouseEvent, isAdd: boolean) => {
+    if (isAdd) {
+      e.preventDefault();
+      setShowSongOrPlaylistBox((prev) => !prev);
+    } else {
+      setShowSongOrPlaylistBox(false);
+    }
   };
 
   return (
@@ -54,7 +59,7 @@ export default function Navbar() {
         aria-label="Bottom navigation"
       >
         <div className="mx-auto grid max-w-md grid-cols-5">
-          {navItems.map(({ id, href, Icon }) => {
+          {navItems.map(({ id, href, label, Icon }) => {
             const isAdd = id === 'add';
             const isActive = isAdd
               ? showSongOrPlaylistBox
@@ -67,8 +72,8 @@ export default function Navbar() {
               <Link
                 key={id}
                 href={href}
-                onClick={isAdd ? handleAddClick : undefined}
-                className="relative flex items-center justify-center py-5 transition-opacity duration-200"
+                onClick={(e) => handleNavClick(e, isAdd)}
+                className="relative flex flex-col items-center justify-center py-2 transition-opacity duration-200"
                 aria-current={isActive ? 'page' : undefined}
               >
                 <Icon
@@ -76,6 +81,15 @@ export default function Navbar() {
                     isActive ? 'opacity-100' : 'opacity-70'
                   } hover:opacity-100`}
                 />
+
+                <span
+                  className={`text-[10px] mt-1 transition-all ${
+                    isActive ? 'opacity-100' : 'opacity-70'
+                  }`}
+                >
+                  {label}
+                </span>
+
                 {/* Black text at full opacity if link is active */}
                 {isActive && (
                   <span className="absolute bottom-2 h-0.5 w-6 rounded-full bg-foreground" />

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Song } from '@/src/lib/db';
 import { db } from '@/src/lib/db';
 import { SongBox } from '../songs/SongBox';
@@ -18,10 +19,32 @@ type Tag = {
 };
 
 export function HomePage({ songs = [], isLoading, error }: SongListProps) {
-  const [searchQuery, setSearchQuery] = useState('');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const searchQuery = searchParams.get('q')
+    ? decodeURIComponent(searchParams.get('q') as string)
+    : '';
+
   const debouncedQuery = useDebounce(searchQuery, 300);
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [isOnline, setIsOnline] = useState(() => window.navigator.onLine);
+
+  const handleSearchChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (value.trim()) {
+      // encode special characters (æ, ø, å)
+      params.set('q', encodeURIComponent(value));
+    } else {
+      params.delete('q');
+    }
+
+    const queryString = params.toString();
+
+    router.replace(queryString ? `${pathname}?${queryString}` : pathname);
+  };
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
@@ -77,7 +100,7 @@ export function HomePage({ songs = [], isLoading, error }: SongListProps) {
         </div>
       ) : (
         <>
-          <SearchField value={searchQuery} onChange={setSearchQuery} />
+          <SearchField value={searchQuery} onChange={handleSearchChange} />
 
           <div className="mb-10 w-fit">
             <TagSelect

--- a/frontend/src/tests/components/pages/HomePage.test.tsx
+++ b/frontend/src/tests/components/pages/HomePage.test.tsx
@@ -7,6 +7,17 @@ vi.mock('dexie-react-hooks', () => ({
   useLiveQuery: vi.fn(),
 }));
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+  }),
+  usePathname: () => '/',
+  useSearchParams: () => ({
+    get: () => null,
+    toString: () => '',
+  }),
+}));
+
 vi.mock('@/src/components/SongBox', () => ({
   SongBox: ({ song }: { song: { id: string; title: string } }) => <div>{song.title}</div>,
 }));


### PR DESCRIPTION
Made small fixes to make the navbar and searchbar more user friendly. Changes made:

- Made the text in the search field slightly bigger to remove the automatic zoom effect that appeared on mobile devices when clicking the search field.
- Changed background colour on the search field to match the input fields in the forms.
- Made the pop up from the "+" icon in the navbar disappear when the user clicks on other icons in the navbar after clicking it.
- Added labels under the icons in the navbar.
- Added search input to the url so search input is remembered after clicking on a song from search.

How to test:

- On a mobile device, click the search field and see that it doesn't automatically zoom when clicking it.
- Check that search bar styling matches other input fields in the app.
- Click the "+" icon in the navbar and then click on another icon in the navbar without clicking any of the options in the pop up first. Make sure the pop up disappears when doing that.
- Search for a song, click on it, and then click "Tilbake" and make sure you get back to your search results instead of all songs.