### PR TITLE
Add link to admindashboard and campfirepage to settings

### DIFF
--- a/frontend/app/campfire/page.tsx
+++ b/frontend/app/campfire/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import Campfire from '@/src/components/Campfire';
+
+export default function CampfirePage() {
+  return <Campfire message="Og tent et bål for å holde deg varm" />;
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -306,6 +306,11 @@ a[href] .no-underline {
   }
 }
 
+.settings-list-item {
+  padding: 0.75rem 0.5rem;
+  border-bottom-width: 1px;
+}
+
 /* -- Fonts --- */
 
 pre {

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,5 +1,5 @@
 import Campfire from '@/src/components/Campfire';
 
 export default function NotFound() {
-  return <Campfire />;
+  return <Campfire message="Denne siden finnes ikke" />;
 }

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -2,14 +2,37 @@
 import HeaderColorForm from '@/src/components/HeaderColorForm';
 import ThemeToggleButton from '@/src/components/ThemeToggleButton';
 import WakeLockToggle from '@/src/components/songs/WakeLockToggle';
+import { useAuth } from '@/src/context/AuthContext';
+import Link from 'next/link';
 
 export default function Settings() {
+  const { isAdmin } = useAuth();
+
   return (
-    <main className="flex flex-col  gap-2">
+    <main>
       <h1>Innstillinger</h1>
-      <WakeLockToggle />
-      <ThemeToggleButton />
-      <HeaderColorForm />
+      <ul className="flex flex-col">
+        <li className="settings-list-item">
+          <WakeLockToggle />
+        </li>
+        <li className="settings-list-item">
+          <ThemeToggleButton />
+        </li>
+
+        <li className="hover:bg-secondary/60 active:bg-none settings-list-item">
+          <HeaderColorForm />
+        </li>
+
+        <Link href="/campfire" className="hover:bg-secondary/60 settings-list-item">
+          Gå en tur i skogen?
+        </Link>
+
+        {isAdmin && (
+          <Link href="/admin/dashboard" className="hover:bg-secondary/60 settings-list-item">
+            Til admin-dashboard
+          </Link>
+        )}
+      </ul>
     </main>
   );
 }

--- a/frontend/src/components/Campfire.tsx
+++ b/frontend/src/components/Campfire.tsx
@@ -3,14 +3,18 @@
 import Image from 'next/image';
 import { useCampfire } from '../hooks/useCampfire';
 
-export default function Campfire() {
+interface Props {
+  message: string;
+}
+
+export default function Campfire({ message }: Props) {
   const { boost, trigger } = useCampfire();
 
   return (
-    <main className="flex flex-col mx-auto items-center justify-center gap-5 text-center min-h-[60vh]">
+    <main className="flex flex-col mx-auto items-center justify-center gap-5 text-center min-h-[50vh]">
       <section>
         <h1 className="mb-0!">Du har gått deg vill i skogen</h1>
-        <h2 className="mt-0 text-lg text-muted-foreground">Denne siden finnes ikke</h2>
+        <h2 className="mt-0 text-lg text-muted-foreground">{message}</h2>
       </section>
       <section
         className="flex flex-col items-center leading-none cursor-pointer mt-7"


### PR DESCRIPTION

**What's done**:
- If authenticated as an admin or superadmin, a link to /admin in displayed in /settings
- Changed campfire-component to take in message-prop changing the h2 subtitle and changed not-found to match
- Made a /campfire page that displays the campfire-component with alternate h2 subtitle
- Linked to /campfire in settings
- Changed style in /settings to look more modern

**How to test**:
- Log in as admin, verify a link to admin is displayed in /settings
- Verify link to /campfire is in /settings, and that the h2 is different from the not-found h2
- Log out as admin, and verify the link to admin is no longer in /settings