### PR TITLE
Change short-name to 1sang

### DIFF
--- a/frontend/app/manifest.ts
+++ b/frontend/app/manifest.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from 'next';
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: 'Sanger under liljen',
-    short_name: 'Liljesanger',
+    short_name: '1sang',
     description: 'A PWA for Fredrikstad Scouts displaying their scout songs',
     start_url: '/',
     display: 'standalone',


### PR DESCRIPTION
Changed the short-name, which is the name displayed on the app when downloaded, to 1sang

**How to test**:
This can only be tested if app is downloaded on phone. Verify the name is '1sang' and not 'Liljesanger'
 