### PR TITLE
Update playlistform use modal to pick songs

### DIFF
--- a/frontend/src/components/playlist/PlaylistForm.tsx
+++ b/frontend/src/components/playlist/PlaylistForm.tsx
@@ -3,11 +3,8 @@
 import { useForm, SubmitHandler, useWatch } from 'react-hook-form';
 import { getPlaylistFieldValidation } from '@/src/lib/validation/playlistSchema';
 import { PlaylistInputs } from '@/src/types/playlistInputs';
-import SongList from './SongList';
 import { useSongs } from '@/src/hooks/useData';
-import { Song } from '@/src/lib/db';
-import { useCallback } from 'react';
-import { toast } from 'sonner';
+import { useState } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import MobileTooltip from '../MobileTooltip';
@@ -22,6 +19,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import PlaylistSongPickerModal from './PlaylistSongPickerModal';
+import { SongBox } from '../songs/SongBox';
 
 type PlaylistFormProps = {
   onSubmit: SubmitHandler<PlaylistInputs>;
@@ -52,40 +51,20 @@ export default function PlaylistForm({
     },
   });
 
-  const songsInPlaylist = useWatch({ name: 'songsInPlaylist', control });
   const isPublic = useWatch({ name: 'isPublic', control });
+  const [open, setOpen] = useState(false);
 
-  const {
-    data: songs,
-    isLoading,
-    error,
-  } = useSongs({
+  const songsInPlaylist = useWatch({
+    name: 'songsInPlaylist',
+    control,
+  });
+
+  const hasSongs = songsInPlaylist.length > 0;
+
+  const { data: songs } = useSongs({
     maxAgeMins: 5,
     syncOnMount: true,
   });
-
-  const isSongAdded = useCallback(
-    (id: string) => songsInPlaylist.some((s) => s.id === id),
-    [songsInPlaylist]
-  );
-
-  const toggleSong = useCallback(
-    (song: Song) => {
-      const exists = songsInPlaylist.some((s) => s.id === song.id);
-
-      if (exists) {
-        setValue(
-          'songsInPlaylist',
-          songsInPlaylist.filter((s) => s.id !== song.id)
-        );
-        toast.error('Sang fjernet');
-      } else {
-        setValue('songsInPlaylist', [...songsInPlaylist, song]);
-        toast.success('Sang lagt til');
-      }
-    },
-    [songsInPlaylist, setValue]
-  );
 
   const handleFormSubmit: SubmitHandler<PlaylistInputs> = async (data) => {
     await onSubmit(data);
@@ -130,13 +109,32 @@ export default function PlaylistForm({
 
         {/* Songlist */}
         <Field>
-          <FieldLabel>Legg til sanger</FieldLabel>
-          <SongList
-            songs={songs}
-            isLoading={isLoading}
-            error={error}
-            onToggleSong={toggleSong}
-            isAdded={isSongAdded}
+          <FieldLabel>
+            {hasSongs ? `Sanger (${songsInPlaylist.length})` : 'Legg til sanger'}
+          </FieldLabel>
+
+          {songsInPlaylist.length > 0 && (
+            <ul className="flex flex-col gap-2 mt-2">
+              {songsInPlaylist.map((song) => (
+                <li key={song.id}>
+                  <SongBox song={song} mode="select" hoverVariant="none" />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="mt-2">
+            <Button type="button" onClick={() => setOpen(true)}>
+              {hasSongs ? 'Endre sanger' : 'Velg sanger'}
+            </Button>
+          </div>
+
+          <PlaylistSongPickerModal
+            songs={songs ?? []}
+            open={open}
+            onOpenChange={setOpen}
+            songsInPlaylist={songsInPlaylist}
+            setSongsInPlaylist={(songs) => setValue('songsInPlaylist', songs)}
           />
         </Field>
 

--- a/frontend/src/components/playlist/PlaylistSongPickerModal.tsx
+++ b/frontend/src/components/playlist/PlaylistSongPickerModal.tsx
@@ -16,21 +16,23 @@ import SongList from '../playlist/SongList';
 import { useSongPicker } from '@/src/hooks/useSongPicker';
 import { SearchField } from '../SearchField';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
-export default function ExportLatexModal({
+export default function PlaylistSongPickerModal({
   songs,
   open,
   onOpenChange,
-  generateLatex,
+  songsInPlaylist,
+  setSongsInPlaylist,
 }: {
   songs: Song[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  generateLatex: (songs: Song[], total?: number) => void;
+  songsInPlaylist: Song[];
+  setSongsInPlaylist: (songs: Song[]) => void;
 }) {
-  const [selectedSongs, setSelectedSongs] = useState<Song[]>([]);
-  const songPicker = useSongPicker(songs, selectedSongs, setSelectedSongs, open);
+  const [localSongs, setLocalSongs] = useState<Song[]>([]);
+
+  const songPicker = useSongPicker(songs, localSongs, setLocalSongs, open);
 
   const {
     search,
@@ -45,13 +47,25 @@ export default function ExportLatexModal({
     selectedCount,
   } = songPicker;
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setLocalSongs(songsInPlaylist);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleSave = () => {
+    setSongsInPlaylist(localSongs);
+    onOpenChange(false);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-xl flex flex-col gap-3 h-[90vh]">
         {/* Header */}
         <DialogHeader>
-          <DialogTitle>Eksporter til LaTeX</DialogTitle>
-          <DialogDescription>Velg hvilke sanger du vil eksportere:</DialogDescription>
+          <DialogTitle>Velg sanger</DialogTitle>
+          <DialogDescription>Legg til i spillelisten:</DialogDescription>
         </DialogHeader>
 
         {/* Toolbar */}
@@ -102,21 +116,10 @@ export default function ExportLatexModal({
             </Button>
           </DialogClose>
 
-          <Button
-            onClick={() => {
-              generateLatex(selectedSongs, songs.length);
-              onOpenChange(false);
-              toast.success(
-                selectedCount === 1
-                  ? 'Eksporterte 1 sang'
-                  : selectedCount === songs.length
-                    ? 'Eksporterte alle sanger'
-                    : `Eksporterte ${selectedCount} sanger`
-              );
-            }}
-            disabled={selectedCount === 0}
-          >
-            Eksporter ({selectedCount})
+          <Button onClick={handleSave} disabled={selectedCount === 0}>
+            {songsInPlaylist.length === 0
+              ? `Legg til sanger (${selectedCount})`
+              : `Lagre endringer (${selectedCount})`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/playlist/SongList.tsx
+++ b/frontend/src/components/playlist/SongList.tsx
@@ -1,9 +1,9 @@
 import { Song } from '@/src/lib/db';
 import { SongBox } from '../songs/SongBox';
 import { SongListProps } from '@/src/types/songList';
-import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useMemo } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export type ExtendedSongListProps = SongListProps & {
   onToggleSong: (song: Song) => void;
@@ -34,40 +34,59 @@ export default function SongList({
   const renderList = (songs: Song[]) =>
     songs.map((song: Song) => (
       <li key={song.id} className="flex items-center gap-2">
-        <Button
-          type="button"
+        <span
           onClick={() => onToggleSong(song)}
-          className={`w-10 h-10 flex items-center justify-center text-2xl shrink-0 rounded-md outline-1 
-                outline-[#0000001a] dark:shadow-xs dark:shadow-black hover:shadow-sm active:scale-[0.99] 
-                transition cursor-pointer text-white ${isAdded(song.id) ? 'bg-red-400' : 'bg-[#58B030]'}`}
+          className="flex-1 hover:shadow-sm active:scale-[0.99] w-full transition cursor-pointer"
         >
-          {isAdded(song.id) ? '-' : '+'}
-        </Button>
-        <span className="flex-1">
-          <SongBox song={song} />
+          <SongBox song={song} mode="select" hoverVariant={isAdded(song.id) ? 'red' : 'green'} />
         </span>
       </li>
     ));
 
   return (
-    <main className="mb-6">
+    <main>
       {isLoading && <Spinner message="Synkroniserer med databasen" />}
 
-      {/* Added songs */}
-      <section>
-        <h2 className="text-sm mb-1">Valgte sanger:</h2>
-        <ul className="flex flex-col gap-2 max-h-64 overflow-y-auto p-2 mb-4">
-          {addedSongs.length > 0 ? renderList(addedSongs) : <li>Ingen valgte sanger</li>}
-        </ul>
-      </section>
+      <Tabs defaultValue="all">
+        {/* Tabs header */}
+        <div className="sticky top-0 z-10 bg-popover isolate">
+          <TabsList className="mb-2">
+            <TabsTrigger
+              value="all"
+              className="data-[state=active]:bg-list-bg data-[state=active]:border-0"
+            >
+              Alle sanger ({availableSongs.length})
+            </TabsTrigger>
 
-      {/* Available songs */}
-      <section>
-        <h2 className="text-sm mb-1">Alle sanger:</h2>
-        <ul className="flex flex-col gap-2 max-h-64 overflow-y-auto p-2">
-          {renderList(availableSongs)}
-        </ul>
-      </section>
+            <TabsTrigger
+              value="selected"
+              className="data-[state=active]:bg-list-bg data-[state=active]:border-0"
+            >
+              Valgte sanger ({addedSongs.length})
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="all">
+          <ul className="flex flex-col gap-2 p-2">
+            {availableSongs.length > 0 ? (
+              renderList(availableSongs)
+            ) : (
+              <li className="text-sm opacity-60">Ingen sanger tilgjengelig</li>
+            )}
+          </ul>
+        </TabsContent>
+
+        <TabsContent value="selected">
+          <ul className="flex flex-col gap-2 p-2">
+            {addedSongs.length > 0 ? (
+              renderList(addedSongs)
+            ) : (
+              <li className="text-sm opacity-60">Ingen valgte sanger</li>
+            )}
+          </ul>
+        </TabsContent>
+      </Tabs>
     </main>
   );
 }

--- a/frontend/src/components/songs/SongBox.tsx
+++ b/frontend/src/components/songs/SongBox.tsx
@@ -6,18 +6,51 @@ import { StarIcon } from '@/src/components/songs/StarIcon';
 
 type SongBoxProps = {
   song: Song;
+  mode?: 'link' | 'select';
+  hoverVariant?: 'default' | 'none' | 'green' | 'red';
 };
 
-export function SongBox({ song }: SongBoxProps) {
-  return (
-    <article className="relative allow-animation rounded-sm outline-1 dark:bg-list-bg outline-[#0000001a] dark:shadow-xs dark:shadow-black hover:shadow-sm active:scale-[0.99] transition">
-      <Link
-        href={`/songs/${song.slug}`}
-        className="block w-full py-4 pr-10 pl-4 text-left capitalize-first"
-      >
+const modeStyles = {
+  link: {
+    hideStar: false,
+  },
+  select: {
+    hideStar: true,
+  },
+} as const;
+
+export function SongBox({ song, mode = 'link', hoverVariant = 'default' }: SongBoxProps) {
+  const config = modeStyles[mode];
+
+  const hoverClasses =
+    {
+      default: '',
+      none: 'active:scale-[1] cursor-default',
+      green: 'hover:bg-green-100 dark:hover:bg-green-950/60',
+      red: 'hover:bg-red-100 dark:hover:bg-red-950/60',
+    }[hoverVariant] ?? '';
+
+  const content = (
+    <article
+      className={`relative allow-animation rounded-sm outline-1 dark:bg-list-bg outline-[#0000001a] dark:shadow-xs dark:shadow-black hover:shadow-sm active:scale-[0.99] transition ${hoverClasses}`}
+    >
+      <div className="block w-full py-4 pr-10 pl-4 text-left capitalize-first">
         {song.title ?? '(uten tittel)'}
-      </Link>
-      <StarIcon songId={song.id} className="absolute right-2 top-1/2 -translate-y-1/2" />
+      </div>
+
+      {!config.hideStar && (
+        <StarIcon songId={song.id} className="absolute right-2 top-1/2 -translate-y-1/2" />
+      )}
     </article>
+  );
+
+  if (mode === 'select') {
+    return <div className="cursor-pointer">{content}</div>;
+  }
+
+  return (
+    <Link href={`/songs/${song.slug}`} className="block">
+      {content}
+    </Link>
   );
 }

--- a/frontend/src/hooks/useSongPicker.ts
+++ b/frontend/src/hooks/useSongPicker.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { Song } from '@/src/lib/db';
-import { toast } from 'sonner';
 import { useMemo, useState } from 'react';
 import { searchSongs } from '@/src/lib/search/searchSongs';
 
@@ -27,10 +26,8 @@ export function useSongPicker(
 
     if (exists) {
       setSongsInPlaylist(songsInPlaylist.filter((s) => s.id !== song.id));
-      toast.error('Sang fjernet');
     } else {
       setSongsInPlaylist([...songsInPlaylist, song]);
-      toast.success('Sang lagt til');
     }
   }
 

--- a/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
+++ b/frontend/src/tests/components/playlist/PlaylistForm.test.tsx
@@ -2,24 +2,20 @@ import { render, screen } from '@testing-library/react';
 import { vi, expect, describe, test } from 'vitest';
 import PlaylistForm from '@/src/components/playlist/PlaylistForm';
 import { Song } from '@/src/lib/db';
-import { ExtendedSongListProps } from '@/src/components/playlist/SongList';
 import userEvent from '@testing-library/user-event';
 
 // ---- mocks ----
-vi.mock('sonner', () => {
-  const mockToastSuccess = vi.fn();
-  const mockToastError = vi.fn();
+vi.mock('sonner', async () => {
+  const actual = (await vi.importActual('sonner')) as typeof import('sonner');
 
   return {
-    __esModule: true,
+    ...actual,
     toast: {
-      success: mockToastSuccess,
-      error: mockToastError,
+      success: vi.fn(),
+      error: vi.fn(),
       update: vi.fn(),
       isActive: vi.fn(() => false),
     },
-    mockToastSuccess,
-    mockToastError,
   };
 });
 
@@ -30,10 +26,18 @@ vi.mock('@/src/hooks/useData', () => ({
   }),
 }));
 
-vi.mock('@/src/components/playlist/SongList', () => ({
-  __esModule: true,
-  default: ({ onToggleSong }: ExtendedSongListProps) => (
-    <button onClick={() => onToggleSong({ id: '1', title: 'Song 1', chorus: '', verses: [''] })}>
+type SongLite = {
+  id: string;
+  title: string;
+  chorus: string;
+  verses: string[];
+};
+
+vi.mock('@/src/components/playlist/PlaylistSongPickerModal', () => ({
+  default: ({ setSongsInPlaylist }: { setSongsInPlaylist: (songs: SongLite[]) => void }) => (
+    <button
+      onClick={() => setSongsInPlaylist([{ id: '1', title: 'Song 1', chorus: '', verses: [] }])}
+    >
       toggle-song
     </button>
   ),
@@ -59,35 +63,6 @@ vi.mock('next/navigation', () => ({
 
 // ---- tests ----
 describe('PlaylistForm', () => {
-  test('adds a song and shows success toast', async () => {
-    const user = userEvent.setup();
-    render(<PlaylistForm onSubmit={vi.fn()} />);
-
-    const toggle = screen.getByText('toggle-song');
-
-    await user.click(toggle);
-
-    // @ts-expect-error access mock inside vi.mock
-    const { mockToastSuccess } = await import('sonner');
-
-    expect(mockToastSuccess).toHaveBeenCalledWith('Sang lagt til');
-  });
-
-  test('removes a song and shows error toast', async () => {
-    const user = userEvent.setup();
-    render(<PlaylistForm onSubmit={vi.fn()} />);
-
-    const toggle = screen.getByText('toggle-song');
-
-    await user.click(toggle); // add
-    await user.click(toggle); // remove
-
-    // @ts-expect-error access mock inside vi.mock
-    const { mockToastError } = await import('sonner');
-
-    expect(mockToastError).toHaveBeenCalledWith('Sang fjernet');
-  });
-
   test('calls onSubmit when form is submitted', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue({
@@ -103,26 +78,6 @@ describe('PlaylistForm', () => {
     await user.click(screen.getByRole('button', { name: /opprett spilleliste/i }));
 
     expect(onSubmit).toHaveBeenCalled();
-  });
-
-  test('renders edit mode correctly', () => {
-    render(
-      <PlaylistForm
-        onSubmit={vi.fn()}
-        mode="edit"
-        initialValues={{
-          title: 'Min spilleliste',
-          password: '',
-          newPassword: '',
-          songsInPlaylist: [],
-          isPublic: false,
-          duration: 604800,
-        }}
-      />
-    );
-
-    expect(screen.getByText(/rediger spilleliste/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /lagre endringer/i })).toBeInTheDocument();
   });
 
   test('renders edit mode correctly', () => {

--- a/frontend/src/tests/components/playlist/SongList.test.tsx
+++ b/frontend/src/tests/components/playlist/SongList.test.tsx
@@ -31,21 +31,7 @@ describe('SongList', () => {
     expect(screen.getByText(/error/i)).toBeInTheDocument();
   });
 
-  test('renders error state', () => {
-    render(
-      <SongList
-        songs={[]}
-        isLoading={false}
-        error={new Error('fail')}
-        onToggleSong={vi.fn()}
-        isAdded={() => false}
-      />
-    );
-
-    expect(screen.getByText(/error/i)).toBeInTheDocument();
-  });
-
-  test('calls onToggleSong when button clicked', async () => {
+  test('calls onToggleSong when song is clicked', async () => {
     const user = userEvent.setup();
     const song = { id: '1', title: 'A' } as Song;
     const onToggleSong = vi.fn();
@@ -60,8 +46,9 @@ describe('SongList', () => {
       />
     );
 
-    await user.click(screen.getByText('+'));
+    await user.click(screen.getByText('A'));
 
+    expect(onToggleSong).toHaveBeenCalledTimes(1);
     expect(onToggleSong).toHaveBeenCalledWith(song);
   });
 });


### PR DESCRIPTION
Refactored and restyled some files.

**What's done**:
- Added a mode variant prop to songbox to vary if it should show a link (like in homepage, this is default) or just a select as used in songlist (no link). Added optional hovervariants for songlist as well, so that it can have hover-colors as used in songlist
- Restyled songlist so it uses tabs to display all songs or selected songs. For consistency of styling and to make it easier for user to view and interact. Removed the + and - buttons and instead made the songboxes clickable, so they are added directly by clicking on them. Hover effect on click.
- Created PlaylistSongPickerModal for playlistform for user to select song. Matches exportlatexmodal, and uses useSongPicker hook. Made small style changes in them to match better with new songlist tab feature
- Updated playlistform to use usesongpicker hook and new modal created. For reusable code. 
- Removed toasts from usesongpicker as it seemed redundant and could be perceived as annoying for users with many toasts
- Updated tests (also removed some duplicate tests and removed the tests testing sonner as they are no longer directly in that code)
- (Did not write a test for playlistsongpickermodal as it is very similar to exportlatexmodal. Might smash these two modals together using a basemodal in a later issue, so I am waiting with writing a test for it in case)

**How to test**:
- Verify tests still run
- Create a playlist and verify you like the style of the new songlist. Verify adding a song work, and removing a song works.
- Verify songbox still works as expected in homepage


