### PR TITLE
Persist close button pwabanner user session

### DIFF
--- a/frontend/src/components/InstallPWABanner/InstallPWABanner.tsx
+++ b/frontend/src/components/InstallPWABanner/InstallPWABanner.tsx
@@ -14,31 +14,34 @@ import {
 } from '@/components/ui/alert-dialog';
 import { InstallButton } from './InstallButton';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { useState } from 'react';
 
 export default function InstallPWABanner() {
-  const { install, dismiss, showInstallButton } = usePWAInstall();
-  const [isOpen, setIsOpen] = useState(true);
+  const { install, dismiss, close, showInstallButton } = usePWAInstall();
 
   // --- Render checks ---
-  if (!showInstallButton || !isOpen) return null;
+  if (!showInstallButton) return null;
 
   return (
-    <AlertDialog open={showInstallButton} onOpenChange={setIsOpen}>
+    <AlertDialog
+      open={showInstallButton}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
       <AlertDialogContent size="sm">
         <AlertDialogHeader>
           <div className="flex flex-row">
             <AlertDialogTitle className="leading-tight px-10">
-              Installer Sanger under Liljen som app
+              Installer 1sang som app
             </AlertDialogTitle>
             <XMarkIcon
-              onClick={() => setIsOpen(false)}
+              onClick={() => close()}
               aria-label="Lukk"
               className="text-red-500 h-7 pl-1 hover:cursor-pointer"
             />
           </div>
           <AlertDialogDescription>
-            Installer appen for bedre opplevelse og offline tilgang!
+            Installer appen for en bedre opplevelse og tilgang offline
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/frontend/src/hooks/usePWAInstall.ts
+++ b/frontend/src/hooks/usePWAInstall.ts
@@ -6,6 +6,8 @@ import ls from 'localstorage-slim';
 const DISMISSED_KEY = 'pwaBannerDismissed';
 const DISMISSED_TTL = 7 * 24 * 60 * 60; // 7 days
 
+const CLOSED_KEY = 'closedPWABanner';
+
 interface IBeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
@@ -24,6 +26,12 @@ export function usePWAInstall() {
     if (typeof window === 'undefined') return false;
     const dismissed = ls.get(DISMISSED_KEY); // Returns NULL if 7 days has passed, TRUE if not
     return !!dismissed;
+  });
+
+  const [isClosed, setIsClosed] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const closed = sessionStorage.getItem(CLOSED_KEY); // Only flags the key
+    return !!closed;
   });
 
   // --- Initial checks ---
@@ -87,12 +95,18 @@ export function usePWAInstall() {
     setIsDismissed(true);
   };
 
+  const close = () => {
+    sessionStorage.setItem(CLOSED_KEY, 'true');
+    setIsClosed(true);
+  };
+
   // --- Derived boolean ---
 
-  const showInstallButton = !!promptEvent && !isInstalled && !isDismissed;
+  const showInstallButton = !!promptEvent && !isInstalled && !isDismissed && !isClosed;
   return {
     install,
     dismiss,
+    close,
     showInstallButton,
   };
 }

--- a/frontend/src/tests/components/InstallPWABanner/InstallPWABanner.test.tsx
+++ b/frontend/src/tests/components/InstallPWABanner/InstallPWABanner.test.tsx
@@ -17,6 +17,7 @@ describe('InstallPWABanner', () => {
     mockUsePWAInstall.mockReturnValue({
       install: vi.fn(),
       dismiss: vi.fn(),
+      close: vi.fn(),
       showInstallButton: false,
     });
 
@@ -28,12 +29,13 @@ describe('InstallPWABanner', () => {
     mockUsePWAInstall.mockReturnValue({
       install: vi.fn(),
       dismiss: vi.fn(),
+      close: vi.fn(),
       showInstallButton: true,
     });
 
     render(<InstallPWABanner />);
 
-    expect(screen.getByText('Installer Sanger under Liljen som app')).toBeInTheDocument();
+    expect(screen.getByText('Installer 1sang som app')).toBeInTheDocument();
 
     expect(screen.getByText('Installer')).toBeInTheDocument();
     expect(screen.getByText('Ikke vis igjen')).toBeInTheDocument();
@@ -46,6 +48,7 @@ describe('InstallPWABanner', () => {
     mockUsePWAInstall.mockReturnValue({
       install: installMock,
       dismiss: vi.fn(),
+      close: vi.fn(),
       showInstallButton: true,
     });
 
@@ -63,6 +66,7 @@ describe('InstallPWABanner', () => {
     mockUsePWAInstall.mockReturnValue({
       install: vi.fn(),
       dismiss: dismissMock,
+      close: vi.fn(),
       showInstallButton: true,
     });
 
@@ -71,5 +75,23 @@ describe('InstallPWABanner', () => {
     await user.click(screen.getByText('Ikke vis igjen'));
 
     expect(dismissMock).toHaveBeenCalled();
+  });
+
+  test('calls close when clicking close button', async () => {
+    const user = userEvent.setup();
+    const closeMock = vi.fn();
+
+    mockUsePWAInstall.mockReturnValue({
+      install: vi.fn(),
+      dismiss: vi.fn(),
+      close: closeMock,
+      showInstallButton: true,
+    });
+
+    render(<InstallPWABanner />);
+
+    await user.click(screen.getByLabelText('Lukk'));
+
+    expect(closeMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**What's done**:
- Added sessionstorage for close button in installpwabanner and hook so that the action persists across the session and does not annoy the user.
- Changed title of app in banner to correct name
- Updated test

**How to test**:
- Verify InstallPWABanner.test.tsx runs successfully
- Uninstall app from computer if installed, and run app. Click on X button (red X in upper right corner, NOT 'ikke vis igjen') when PWA banner pops up. Go to other pages in app and verify pwa banner does not pop up again. Close session, and open in new tab. Verify banner opens up again.
-  Close banner when it pops up. Go into dev mode > application > sessionstorage, and verify a key called closedPWABanner exists. Delete key. Verify banner pops up again.
