### PR TITLE
Fix sorting bug + some other small bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-	"conventionalCommits.scopes": ["frontend", "format", "setup", "songform", "colortheme", "pwabanner", "adminaccess", "loading", "latex"]
+	"conventionalCommits.scopes": [
+		"frontend",
+		"format",
+		"setup",
+		"songform",
+		"colortheme",
+		"pwabanner",
+		"adminaccess",
+		"loading",
+		"latex"
+	]
 }

--- a/frontend/app/add/page.tsx
+++ b/frontend/app/add/page.tsx
@@ -5,10 +5,12 @@ import { Suspense } from 'react';
 import { useAuth } from '@/src/context/AuthContext';
 import { createClient } from '@/src/lib/supabase/client';
 import { syncService } from '@/src/lib/syncService';
+import { useRouter } from 'next/navigation';
 
 export default function AddSongPage() {
   const { isAdmin } = useAuth();
   const supabase = createClient();
+  const router = useRouter();
 
   if (isAdmin === null) {
     return <div>Henter skjema...</div>;
@@ -56,6 +58,8 @@ export default function AddSongPage() {
           if (!res.ok || body?.error) {
             throw new Error('Kunne ikke legge til sang');
           }
+
+          router.push('/');
         }}
       />
     </Suspense>

--- a/frontend/app/admin/(protected)/suggestions/[id]/edit/page.tsx
+++ b/frontend/app/admin/(protected)/suggestions/[id]/edit/page.tsx
@@ -62,8 +62,8 @@ export default function EditSuggestionPage() {
               author: data.author || undefined,
               chorus: data.chorus || undefined,
               verses: data.verses,
-              spotify_youtube: suggestion.spotify_youtube || undefined,
-              has_chords: suggestion.has_chords,
+              spotify_youtube: data.spotify_youtube || undefined,
+              has_chords: data.has_chords,
             });
 
             // Keep Dexie cache in sync immdiately after update
@@ -73,9 +73,8 @@ export default function EditSuggestionPage() {
               console.log('Dexie updated manually:', updatedRow.title);
             }
 
-            toast('Forslag oppdatert!');
             router.push(`/admin/suggestions/${id}`);
-            router.refresh();
+            // router.refresh();
           } catch (err: unknown) {
             console.error(err);
             const message = err instanceof Error ? err.message : 'Ukjent feil';

--- a/frontend/app/admin/(protected)/suggestions/[id]/page.tsx
+++ b/frontend/app/admin/(protected)/suggestions/[id]/page.tsx
@@ -106,7 +106,7 @@ export default function SuggestionPage() {
 
       {/* Lyrics */}
       <pre className="mt-8 flex justify-center text-center whitespace-pre-wrap">
-        <Lyrics chorus={suggestion.chorus} verses={suggestion.verses} showChords={showChords} />
+        <Lyrics song={suggestion} showChords={showChords} />
       </pre>
 
       {/* Author */}

--- a/frontend/app/favorites/page.tsx
+++ b/frontend/app/favorites/page.tsx
@@ -19,7 +19,9 @@ export default function FavoritesPage() {
   // Sort using Norwegian locale (handles æ, ø, å correctly)
   const sortedSongs = useMemo(() => {
     return [...(songs ?? [])].sort((a, b) =>
-      (a.title ?? '').trim().localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant' })
+      (a.title ?? '')
+        .trim()
+        .localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant', numeric: true })
     );
   }, [songs]);
 

--- a/frontend/app/playlists/page.tsx
+++ b/frontend/app/playlists/page.tsx
@@ -26,7 +26,9 @@ export default function PlaylistsPage() {
   // Sort public playlists
   const sortedPublicPlaylists = useMemo(() => {
     return [...(publicPlaylists ?? [])].sort((a, b) =>
-      (a.title ?? '').trim().localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant' })
+      (a.title ?? '')
+        .trim()
+        .localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant', numeric: true })
     );
   }, [publicPlaylists]);
 
@@ -37,7 +39,7 @@ export default function PlaylistsPage() {
       .sort((a, b) =>
         (a.title ?? '')
           .trim()
-          .localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant' })
+          .localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'variant', numeric: true })
       );
   }, [playlistsFromDexie]);
 

--- a/frontend/app/songs/[slug]/page.tsx
+++ b/frontend/app/songs/[slug]/page.tsx
@@ -15,15 +15,20 @@ import { Switch } from '@/components/ui/switch';
 import { StarIcon } from '@/src/components/songs/StarIcon';
 
 export default function SongPage() {
+  // Read dynamic route param: /songs/[slug]
   const { slug } = useParams<{ slug: string }>();
+  // Check whether current user is admin
   const { isAdmin } = useAuth();
+  // Toggle for showing/hiding chords in lyrics
   const [showChords, setShowChords] = useState(false);
 
+  // Load song by slug from IndexedDB
   const song = useLiveQuery<Song | undefined>(
     () => (slug ? db.songs.where('slug').equals(slug).first() : undefined),
     [slug]
   );
 
+  // Load tags connected to the song through relation table
   const tags = useLiveQuery(async () => {
     if (!song?.id) return [];
 
@@ -36,6 +41,7 @@ export default function SongPage() {
     return await db.tags.where('id').anyOf(tagIds).toArray();
   }, [song?.id]);
 
+  // Loading state while song is fetched
   if (!song) {
     return (
       <div className="flex justify-center items-center min-h-screen text-center">
@@ -44,6 +50,7 @@ export default function SongPage() {
     );
   }
 
+  // Detect platform from external song link
   const getLinkPlatform = (url: string) => {
     try {
       const hostname = new URL(url).hostname;
@@ -55,14 +62,17 @@ export default function SongPage() {
         return { name: 'YouTube', icon: FaYoutube, color: 'text-red-500' };
       }
     } catch {
+      // Invalid URL fallback
       return { name: 'Link' };
     }
-
+    // Default fallback
     return { name: 'Link' };
   };
 
+  // Platform display info for current song link
   const { name, icon: Icon, color } = getLinkPlatform(song.spotify_youtube || '');
 
+  // Check whether song contains chord markers like [G], [Am], etc.
   const hasChords = song.verses?.some((v) => v.includes('[')) || song.chorus?.includes('[');
 
   return (
@@ -118,8 +128,9 @@ export default function SongPage() {
           </div>
         )}
 
+        {/* Lyrics */}
         <pre className="mt-5 flex justify-center text-center whitespace-pre-wrap">
-          <Lyrics chorus={song.chorus} verses={song.verses} showChords={showChords} />{' '}
+          <Lyrics song={song} showChords={showChords} />{' '}
         </pre>
 
         {/* Author */}

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -84,7 +84,9 @@ export function HomePage({ songs = [], isLoading, error }: SongListProps) {
       // 'no' - gives correct norwegian sorting (æ, ø, å)
       // sensitivity 'base' - lowercase and uppercase doesn't affect sorting
       (a, b) =>
-        (a.title ?? '').trim().localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'base' })
+        (a.title ?? '')
+          .trim()
+          .localeCompare((b.title ?? '').trim(), 'no', { sensitivity: 'base', numeric: true })
     );
   }, [filteredSongs]);
 

--- a/frontend/src/components/songs/Lyrics.tsx
+++ b/frontend/src/components/songs/Lyrics.tsx
@@ -1,30 +1,50 @@
+import { Song } from '@/src/lib/db';
 import { parseChordText } from '@/src/lib/utils/chordUtils';
 
 type LyricsProps = {
-  chorus?: string;
-  verses: string[];
+  song: Song;
   showChords?: boolean;
 };
 
-export default function Lyrics({ chorus, verses, showChords = false }: LyricsProps) {
+// Songs that should end with a verse instead of a final chorus
+// (based on customers earlier songs)
+const SPECIAL_LAST_VERSE_SONGS = new Set([
+  'Nelaug, 1990',
+  'Helt vilt, 2017 landsleir Bodø',
+  'Dotømmervise',
+  'Adieu',
+  'Country Roads',
+]);
+
+export default function Lyrics({ song, showChords = false }: LyricsProps) {
+  // Check if if song should skip chorus after final verse (lastVerse)
+  const isSpecialSong = SPECIAL_LAST_VERSE_SONGS.has(song.title || '');
+
+  // Renders a verse or chorus block line by line
   const renderSection = (text: string) => {
+    // Convert escaped "\n" into real line breaks, then split into lines
     const lines = text.replace(/\\n/g, '\n').split('\n');
 
     return lines.map((line, i) => {
+      // If chords are hidden, remove markers like [G], [Am], ...
       if (!showChords) {
         return <div key={i}>{line.replace(/\[[^\]]+\]/g, '')}</div>;
       }
 
+      // Parse line into tokens containing words + optional chords
       const tokens = parseChordText(line);
 
       return (
         <div key={i}>
+          {/* Inline chord/word layout */}
           <span className="inline-flex flex-wrap leading-[1.2]">
             {tokens.map((token, j) => (
               <span key={j} className="mr-1 inline-flex flex-col">
+                {/* Chord shown above word */}
                 <span className="min-h-[1.1em] text-[0.7em] font-medium leading-none">
                   {token.chords?.join('/') || '\u00A0'}
                 </span>
+                {/* Lyric word */}
                 <span className="leading-[1.8]">{token.word}</span>
               </span>
             ))}
@@ -36,19 +56,41 @@ export default function Lyrics({ chorus, verses, showChords = false }: LyricsPro
 
   return (
     <section>
-      {verses.map((verse, i) => (
-        <div key={i}>
-          {renderSection(verse)}
-          {'\n\n'}
-          {chorus && i < verses.length - 1 && (
-            <>
-              <strong>Ref: </strong>
-              {renderSection(chorus)}
+      {isSpecialSong
+        ? song.verses.map((verse, i) => (
+            <div key={i}>
+              {/* Render verse */}
+              {renderSection(verse)}
               {'\n\n'}
-            </>
-          )}
-        </div>
-      ))}
+
+              {/* For special songs:
+                  show chorus after every verse EXCEPT the final verse */}
+              {song.chorus && i !== song.verses.length - 1 && (
+                <>
+                  <strong>Ref: </strong>
+                  {renderSection(song.chorus)}
+                  {'\n\n'}
+                </>
+              )}
+            </div>
+          ))
+        : song.verses.map((verse, i) => (
+            <div key={i}>
+              {/* Render verse */}
+              {renderSection(verse)}
+              {'\n\n'}
+
+              {/* Standard songs:
+                  show chorus after every verse */}
+              {song.chorus && (
+                <>
+                  <strong>Ref: </strong>
+                  {renderSection(song.chorus)}
+                  {'\n\n'}
+                </>
+              )}
+            </div>
+          ))}
     </section>
   );
 }

--- a/frontend/src/components/songs/SongForm.tsx
+++ b/frontend/src/components/songs/SongForm.tsx
@@ -7,7 +7,6 @@ import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
 import TagSelect from '../TagSelect';
 import SubmitButton from '../SubmitButton';
-import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import SectionInput from '../SectionInput';
 import ChordPreview from '../chords/ChordPreview';
@@ -87,8 +86,6 @@ export default function SongForm({
     },
   });
 
-  const router = useRouter();
-
   /**
    * Hydrate form when editing existing song.
    * React Hook Form does NOT update defaultValues after mount,
@@ -151,7 +148,6 @@ export default function SongForm({
       await onSubmit(payload);
 
       toast.success(toastSuccessMessage);
-      router.push('/');
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : 'Noe gikk galt');

--- a/frontend/src/components/songs/SongForm.tsx
+++ b/frontend/src/components/songs/SongForm.tsx
@@ -10,7 +10,7 @@ import SubmitButton from '../SubmitButton';
 import { Button } from '@/components/ui/button';
 import SectionInput from '../SectionInput';
 import ChordPreview from '../chords/ChordPreview';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Switch } from '@/components/ui/switch';
 
 /**
@@ -87,6 +87,33 @@ export default function SongForm({
   });
 
   /**
+   * Reactive field subscriptions (UI-only derived values)
+   * useWatch ensures component re-renders when values change.
+   */
+  const chorusValue = useWatch({ control, name: 'chorus' }) || '';
+  const chorusCharCount = chorusValue.length;
+
+  const watchVerses = useWatch({ control, name: 'verses' }) || [];
+
+  /**
+   * Chorus UI toggle (local UI state, not persisted field)
+   * Controls whether chorus input exists in the form.
+   */
+  // const [hasChorus, sethasChorus] = useState(false);
+  const hasChorus = !!chorusValue.trim();
+
+  /**
+   * Chords toggle stored in form state (boolean)
+   */
+  const hasChords = useWatch({
+    control,
+    name: 'has_chords',
+    defaultValue: false,
+  });
+
+  const selectedTags = useWatch({ control, name: 'tags' }) ?? [];
+
+  /**
    * Hydrate form when editing existing song.
    * React Hook Form does NOT update defaultValues after mount,
    * so reset() is required when initialValues arrives async.
@@ -105,32 +132,6 @@ export default function SongForm({
       has_chords: initialValues.has_chords ?? false,
     });
   }, [initialValues, reset]);
-
-  /**
-   * Reactive field subscriptions (UI-only derived values)
-   * useWatch ensures component re-renders when values change.
-   */
-  const chorusValue = useWatch({ control, name: 'chorus' }) || '';
-  const chorusCharCount = chorusValue.length;
-
-  const watchVerses = useWatch({ control, name: 'verses' }) || [];
-
-  /**
-   * Chorus UI toggle (local UI state, not persisted field)
-   * Controls whether chorus input exists in the form.
-   */
-  const [hasChorus, sethasChorus] = useState(false);
-
-  /**
-   * Chords toggle stored in form state (boolean)
-   */
-  const hasChords = useWatch({
-    control,
-    name: 'has_chords',
-    defaultValue: false,
-  });
-
-  const selectedTags = useWatch({ control, name: 'tags' }) ?? [];
 
   /**
    * Submit handler:
@@ -287,7 +288,6 @@ export default function SongForm({
             error={errors.chorus?.message}
             removable
             onRemove={() => {
-              sethasChorus(false);
               setValue('chorus', '');
               clearErrors('chorus');
             }}
@@ -300,7 +300,7 @@ export default function SongForm({
             <Button
               type="button"
               onClick={() => {
-                sethasChorus(true);
+                setValue('chorus', '');
               }}
               className="cursor-pointer hover:bg-btn-hover"
             >

--- a/frontend/src/components/songs/SongForm.tsx
+++ b/frontend/src/components/songs/SongForm.tsx
@@ -10,7 +10,7 @@ import SubmitButton from '../SubmitButton';
 import { Button } from '@/components/ui/button';
 import SectionInput from '../SectionInput';
 import ChordPreview from '../chords/ChordPreview';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Switch } from '@/components/ui/switch';
 
 /**
@@ -99,8 +99,7 @@ export default function SongForm({
    * Chorus UI toggle (local UI state, not persisted field)
    * Controls whether chorus input exists in the form.
    */
-  // const [hasChorus, sethasChorus] = useState(false);
-  const hasChorus = !!chorusValue.trim();
+  const [hasChorus, setHasChorus] = useState(!!initialValues?.chorus);
 
   /**
    * Chords toggle stored in form state (boolean)
@@ -290,6 +289,7 @@ export default function SongForm({
             onRemove={() => {
               setValue('chorus', '');
               clearErrors('chorus');
+              setHasChorus(false);
             }}
             removeText="refreng"
             charCount={chorusCharCount}
@@ -300,7 +300,7 @@ export default function SongForm({
             <Button
               type="button"
               onClick={() => {
-                setValue('chorus', '');
+                setHasChorus(true);
               }}
               className="cursor-pointer hover:bg-btn-hover"
             >


### PR DESCRIPTION
### Fixed:
- Number sorting bug - 2 comes before 11, etc. (sorting takes numbers into account)
- Routing back to song page when edit a song suggestion as admin
- Spotify/YouTube link and chords updates when changed in edit mode of a song suggestion
- State of chords and chorus is stable, so, they are automatically toggled when going into edit mode of a song suggestion

### How to test
- Go to: Homepage, Playlists page, or Favorites page to check that the sorting of numbers is correct
- Go to admin dashboard and try to edit a song suggestion and then click "Lagre endringer" to see if you're rerouted back to the song you were just looking at/editing
- In admin dashboard, edit song suggestion and change link and chords to see if they change when saving
- In edit mode, if not already added, add chorus, and save, and then go back into editing mode to see if the block of chorus stays open