### PR TITLE
Implement better descriptions on errors

### DIFF
--- a/frontend/app/add/page.tsx
+++ b/frontend/app/add/page.tsx
@@ -55,10 +55,16 @@ export default function AddSongPage() {
           await syncService.syncTable('tags', { forceFresh: true });
           const body = await res.json().catch(() => null);
 
-          if (!res.ok || body?.error) {
-            throw new Error('Kunne ikke legge til sang');
-          }
+          if (!res.ok) {
+            const errorMessage =
+              typeof body?.error === 'string' ? body.error : (body?.error?.message ?? '');
 
+            throw new Error(
+              errorMessage.includes('songs_title_key') || errorMessage.includes('songs_slug_key')
+                ? 'Det finnes allerede en sang med denne tittelen'
+                : 'Kunne ikke legge til sangen'
+            );
+          }
           router.push('/');
         }}
       />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.2",
         "react-icons": "^5.6.0",
-        "react-toastify": "^11.0.5",
+        "react-swipeable": "^7.0.2",
         "server-only": "^0.0.1",
         "shadcn": "^4.0.8",
         "sonner": "^2.0.7",
@@ -13676,17 +13676,13 @@
         }
       }
     },
-    "node_modules/react-toastify": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
-      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
       "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
       "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {

--- a/frontend/src/components/suggestions/SuggestionActions.tsx
+++ b/frontend/src/components/suggestions/SuggestionActions.tsx
@@ -41,7 +41,7 @@ export function SuggestionActions({ id }: Props) {
       setTimeout(() => router.push('/admin'), 300);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Ukjent feil';
-      toast(message || 'Kunne ikke godkjenne');
+      toast.error(message || 'Kunne ikke godkjenne');
     }
   }
 

--- a/frontend/src/lib/actions/songSuggestions.ts
+++ b/frontend/src/lib/actions/songSuggestions.ts
@@ -99,7 +99,13 @@ export async function approveSuggestion(id: string) {
 
   if (insertErr) {
     console.error(insertErr);
-    throw new Error('Kunne ikke legge til sang');
+    const errorMessage = insertErr.message ?? '';
+
+    throw new Error(
+      errorMessage.includes('songs_title_key') || errorMessage.includes('songs_slug_key')
+        ? 'Det finnes allerede en sang med denne tittelen'
+        : 'Kunne ikke legge til sangen'
+    );
   }
 
   // 3. Remove original suggestion

--- a/frontend/src/lib/validation/songSuggestionSchema.ts
+++ b/frontend/src/lib/validation/songSuggestionSchema.ts
@@ -1,6 +1,6 @@
 import { capitalizeFirst } from '../utils/capitalizeFormat';
 
-export const TEXT_PATTERN = /^[a-zA-ZæøåÆØÅ0-9\s.\-/:;,'’*!?()"…–]+$/;
+export const TEXT_PATTERN = /^[a-zA-ZæøåöÖÆØÅ0-9\s.\-/:;,'’*!?()"…–]+$/;
 export const LYRICS_PATTERN = /^[\s\S]+$/;
 
 export const songSuggestionSchema = {


### PR DESCRIPTION
Whats been done:
- Changed the duplicate-title error message for both "Publiser sang" and when clicking "Godkjenn" in the admin dashboard.
- Added the letter Ö to the text pattern for song titles

How to test:
- Try publishing a song with a title that already exists, and verify that a red error toast appears with the message: "Det finnes allerede en sang med denne tittelen"
- Go to the admin dashboard, approve a song suggestion with a title that already exists, and verify that the same red error toast appears
- Enter a song title containing the newly supported letter, and verify that the title is accepted without validation error
- Check if there are any other unclear or inconsistent error messages