### PR TITLE
DRAFT - Remove additionalPrecacheEntries and set cacheOnNavigation to false

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,18 +4,9 @@ import withSerwistInit from '@serwist/next';
 const withSerwist = withSerwistInit({
   swSrc: 'src/sw.ts',
   swDest: 'public/sw.js',
-  cacheOnNavigation: true,
+  cacheOnNavigation: false,
   reloadOnOnline: false,
   disable: process.env.NODE_ENV === 'development',
-  additionalPrecacheEntries: [
-    { url: '/', revision: null },
-    { url: '/campfire', revision: null },
-    { url: '/favorites', revision: null },
-    { url: '/settings', revision: null },
-    { url: '/make_playlist', revision: null },
-    { url: '/playlists', revision: null },
-    { url: '/add', revision: null },
-  ],
 });
 
 const nextConfig: NextConfig = {

--- a/frontend/src/components/ServiceWorkerRegister.tsx
+++ b/frontend/src/components/ServiceWorkerRegister.tsx
@@ -1,14 +1,39 @@
 'use client';
 import { useEffect } from 'react';
 
+const PAGES_TO_CACHE = [
+  '/',
+  '/campfire',
+  '/favorites',
+  '/settings',
+  '/make_playlist',
+  '/playlists',
+  '/add',
+];
+
+async function warmCache() {
+  await Promise.allSettled(
+    PAGES_TO_CACHE.flatMap((url) => [
+      fetch(url, { priority: 'low' }),
+      fetch(url, { headers: { RSC: '1', 'Next-Router-Prefetch': '1' }, priority: 'low' }),
+    ])
+  );
+}
+
 export default function ServiceWorkerRegister() {
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker
-        .register('/sw.js')
-        .then(() => console.log('SW registered'))
-        .catch((err) => console.error('SW registration failed:', err));
-    }
+    if (!('serviceWorker' in navigator)) return;
+
+    navigator.serviceWorker
+      .register('/sw.js')
+      .then((reg) => {
+        if (reg.active) {
+          warmCache();
+        } else {
+          reg.addEventListener('activate', () => warmCache());
+        }
+      })
+      .catch((err) => console.error('SW registration failed:', err));
   }, []);
 
   return null;

--- a/frontend/src/components/ServiceWorkerRegister.tsx
+++ b/frontend/src/components/ServiceWorkerRegister.tsx
@@ -1,39 +1,13 @@
 'use client';
 import { useEffect } from 'react';
 
-const PAGES_TO_CACHE = [
-  '/',
-  '/campfire',
-  '/favorites',
-  '/settings',
-  '/make_playlist',
-  '/playlists',
-  '/add',
-];
-
-async function warmCache() {
-  await Promise.allSettled(
-    PAGES_TO_CACHE.flatMap((url) => [
-      fetch(url, { priority: 'low' }),
-      fetch(url, { headers: { RSC: '1', 'Next-Router-Prefetch': '1' }, priority: 'low' }),
-    ])
-  );
-}
-
 export default function ServiceWorkerRegister() {
   useEffect(() => {
-    if (!('serviceWorker' in navigator)) return;
-
-    navigator.serviceWorker
-      .register('/sw.js')
-      .then((reg) => {
-        if (reg.active) {
-          warmCache();
-        } else {
-          reg.addEventListener('activate', () => warmCache());
-        }
-      })
-      .catch((err) => console.error('SW registration failed:', err));
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch((err) => console.error('SW registration failed:', err));
+    }
   }, []);
 
   return null;

--- a/frontend/src/context/AuthProviderInner.tsx
+++ b/frontend/src/context/AuthProviderInner.tsx
@@ -24,55 +24,68 @@ export const AuthProviderInner = ({ children }: { children: ReactNode }) => {
     isMounted.current = true;
 
     const fetchAdminStatus = async (accessToken: string) => {
-      const res = await fetch('/api/users/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      const body = await res.json().catch(() => null);
-
-      if (!isMounted.current) return;
-      setIsAdmin(body?.isAdmin === true);
-      setIsSuperuser(body?.isSuperuser === true);
-
-      setUser((prev) =>
-        prev
-          ? {
-              ...prev,
-              role: body?.role ?? null,
-            }
-          : null
-      );
-    };
-
-    const updateAuthState = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
-      if (!isMounted.current) return;
-
-      if (session?.user) {
-        setUser({
-          name: session.user.user_metadata.full_name ?? session.user.email ?? 'User',
-          email: session.user.email ?? '',
-          role: null,
+      try {
+        const res = await fetch('/api/users/me', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         });
 
-        if (session.access_token) {
-          await fetchAdminStatus(session.access_token);
-        } else {
-          setIsAdmin(false);
-          setIsSuperuser(false);
-        }
-      } else {
-        setUser(null);
+        const body = await res.json().catch(() => null);
+
+        if (!isMounted.current) return;
+        setIsAdmin(body?.isAdmin === true);
+        setIsSuperuser(body?.isSuperuser === true);
+
+        setUser((prev) =>
+          prev
+            ? {
+                ...prev,
+                role: body?.role ?? null,
+              }
+            : null
+        );
+      } catch {
+        if (!isMounted.current) return;
         setIsAdmin(false);
         setIsSuperuser(false);
       }
+    };
 
-      setIsInitialized(true);
+    const updateAuthState = async () => {
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
+        if (!isMounted.current) return;
+
+        if (session?.user) {
+          setUser({
+            name: session.user.user_metadata.full_name ?? session.user.email ?? 'User',
+            email: session.user.email ?? '',
+            role: null,
+          });
+
+          if (session.access_token) {
+            await fetchAdminStatus(session.access_token);
+          } else {
+            setIsAdmin(false);
+            setIsSuperuser(false);
+          }
+        } else {
+          setUser(null);
+          setIsAdmin(false);
+          setIsSuperuser(false);
+        }
+      } catch {
+        if (!isMounted.current) return;
+        setUser(null);
+        setIsAdmin(false);
+        setIsSuperuser(false);
+      } finally {
+        if (isMounted.current) setIsInitialized(true);
+      }
     };
 
     updateAuthState();

--- a/frontend/src/hooks/usePublicPlaylists.ts
+++ b/frontend/src/hooks/usePublicPlaylists.ts
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Playlist } from '../lib/db';
+import { db, Playlist } from '../lib/db';
 
 type State = {
   data: Playlist[];
@@ -27,8 +27,9 @@ export function usePublicPlaylists(): State {
         }
 
         setData(json.data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
+      } catch {
+        const local = await db.playlists.filter((p) => p.is_public).toArray();
+        setData(local);
       } finally {
         setIsLoading(false);
       }

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -39,6 +39,35 @@ function shellCacheKeyPlugin(shellPrefix: string) {
   };
 }
 
+const PAGES_TO_CACHE = [
+  '/',
+  '/campfire',
+  '/favorites',
+  '/settings',
+  '/make_playlist',
+  '/playlists',
+  '/add',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open('pages');
+      const origin = self.location.origin;
+      await Promise.allSettled(
+        PAGES_TO_CACHE.flatMap((path) => [
+          fetch(path).then((res) => {
+            if (res.ok) return cache.put(`${origin}${path}`, res);
+          }),
+          fetch(path, { headers: { RSC: '1' } }).then((res) => {
+            if (res.ok) return cache.put(`${origin}${path}?_type=rsc`, res);
+          }),
+        ])
+      );
+    })()
+  );
+});
+
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
@@ -79,6 +108,13 @@ const serwist = new Serwist({
       handler: new NetworkFirst({
         cacheName: 'pages',
         plugins: [
+          {
+            cacheKeyWillBeUsed: async ({ request }: { request: Request }) => {
+              const url = new URL(request.url);
+              const suffix = isRSCRequest(request, url) ? '?_type=rsc' : '';
+              return `${url.origin}${url.pathname}${suffix}`;
+            },
+          },
           new CacheableResponsePlugin({ statuses: [0, 200] }),
           new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 }),
         ],

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -2,7 +2,7 @@
 
 import { defaultCache } from '@serwist/next/worker';
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
-import { Serwist, StaleWhileRevalidate, CacheFirst } from 'serwist';
+import { Serwist, StaleWhileRevalidate, CacheFirst, NetworkFirst } from 'serwist';
 import { CacheableResponsePlugin, ExpirationPlugin } from 'serwist';
 
 declare global {
@@ -12,6 +12,32 @@ declare global {
 }
 
 declare const self: ServiceWorkerGlobalScope;
+
+function isRSCRequest(request: Request, url: URL): boolean {
+  return (
+    request.headers.get('RSC') === '1' ||
+    url.searchParams.has('_rsc') ||
+    request.headers.has('Next-Router-State-Tree')
+  );
+}
+
+function isPageRequest(request: Request, url: URL): boolean {
+  if (url.origin !== self.location.origin) return false;
+  if (url.pathname.startsWith('/_next/')) return false;
+  if (url.pathname.startsWith('/api/')) return false;
+  if (request.method !== 'GET') return false;
+  return request.mode === 'navigate' || isRSCRequest(request, url);
+}
+
+function shellCacheKeyPlugin(shellPrefix: string) {
+  return {
+    cacheKeyWillBeUsed: async ({ request }: { request: Request }) => {
+      const url = new URL(request.url);
+      const suffix = isRSCRequest(request, url) ? '_rsc' : '_html';
+      return `${url.origin}${shellPrefix}${suffix}`;
+    },
+  };
+}
 
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
@@ -24,7 +50,40 @@ const serwist = new Serwist({
     ignoreURLParametersMatching: [/.*/],
   },
   runtimeCaching: [
-    // Next.js static assets
+    {
+      matcher: ({ request, url }) =>
+        isPageRequest(request, url) && /^\/songs\/[^/]+$/.test(url.pathname),
+      handler: new NetworkFirst({
+        cacheName: 'song-shells',
+        plugins: [
+          shellCacheKeyPlugin('/songs/_shell'),
+          new CacheableResponsePlugin({ statuses: [0, 200] }),
+          new ExpirationPlugin({ maxEntries: 10, maxAgeSeconds: 60 * 60 * 24 * 30 }),
+        ],
+      }),
+    },
+    {
+      matcher: ({ request, url }) =>
+        isPageRequest(request, url) && /^\/playlists\/[^/]+$/.test(url.pathname),
+      handler: new NetworkFirst({
+        cacheName: 'playlist-shells',
+        plugins: [
+          shellCacheKeyPlugin('/playlists/_shell'),
+          new CacheableResponsePlugin({ statuses: [0, 200] }),
+          new ExpirationPlugin({ maxEntries: 10, maxAgeSeconds: 60 * 60 * 24 * 30 }),
+        ],
+      }),
+    },
+    {
+      matcher: ({ request, url }) => isPageRequest(request, url),
+      handler: new NetworkFirst({
+        cacheName: 'pages',
+        plugins: [
+          new CacheableResponsePlugin({ statuses: [0, 200] }),
+          new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 30 }),
+        ],
+      }),
+    },
     {
       matcher: ({ url }) => url.pathname.startsWith('/_next/static/'),
       handler: new StaleWhileRevalidate({
@@ -35,7 +94,6 @@ const serwist = new Serwist({
         ],
       }),
     },
-    // Your public folder assets — fonts, icons, images, audio
     {
       matcher: ({ url }) =>
         url.pathname.startsWith('/DINOT/') ||
@@ -52,55 +110,6 @@ const serwist = new Serwist({
     },
     ...defaultCache,
   ],
-});
-
-// Dynamic route shell caching (/songs/[slug], /playlists/[id])
-self.addEventListener('fetch', (event: FetchEvent) => {
-  const url = new URL(event.request.url);
-
-  if (url.origin !== self.location.origin) return;
-  if (url.pathname.startsWith('/_next/')) return;
-  if (url.pathname.startsWith('/api/')) return;
-  if (url.pathname === '/manifest.webmanifest') return;
-  if (event.request.method !== 'GET') return;
-
-  const isRSC =
-    event.request.headers.get('RSC') === '1' ||
-    url.searchParams.has('_rsc') ||
-    event.request.headers.has('Next-Router-State-Tree');
-
-  const isNavigate = event.request.mode === 'navigate';
-
-  const isDynamicRoute =
-    (url.pathname.startsWith('/songs/') && url.pathname !== '/songs/') ||
-    (url.pathname.startsWith('/playlists/') && url.pathname !== '/playlists/');
-
-  if (!isDynamicRoute) return;
-  if (!isNavigate && !isRSC) return;
-
-  event.respondWith(
-    (async () => {
-      const rscKey = url.pathname.startsWith('/songs/') ? '/songs/_shell' : '/playlists/_shell';
-      const htmlKey = rscKey.replace('_shell', '_html');
-      const cacheKey = isRSC ? rscKey : htmlKey;
-      const cacheName = isRSC ? 'dynamic-rsc' : 'dynamic-pages';
-
-      try {
-        const response = await fetch(event.request);
-        if (response.ok) {
-          const cache = await caches.open(cacheName);
-          cache.put(cacheKey, response.clone());
-        }
-        return response;
-      } catch {
-        const cache = await caches.open(cacheName);
-        const cached = await cache.match(cacheKey);
-        if (cached) return cached;
-        // Last resort: serve precached shell
-        return (await caches.match('/', { ignoreSearch: true })) ?? Response.error();
-      }
-    })()
-  );
 });
 
 serwist.addEventListeners();


### PR DESCRIPTION
- Removed additionalPrecacheEntries due to pre-cached pages was mismatched with RSC requests, causing React-tree crash
- Set cacheOnNavigation to false, same problem

- Added NetworkFirst runtime caching for all page requests. Handles both navigate and RSC

If the service worker is active, then all pages will be fetched in the background with priority = "low", both as RSC and HTML. 

