### PR TITLE
Expand api tests to test all routes

### DIFF
--- a/frontend/app/api/admin/users/route.ts
+++ b/frontend/app/api/admin/users/route.ts
@@ -37,11 +37,7 @@ export async function GET(req: NextRequest) {
     const usersBody = await usersRes.json().catch(() => null);
 
     if (!usersRes.ok) {
-      throw new Error(
-        typeof usersBody === 'object' && usersBody !== null
-          ? JSON.stringify(usersBody)
-          : 'Kunne ikke hente brukere'
-      );
+      throw new Error('Kunne ikke hente brukere');
     }
 
     return NextResponse.json({

--- a/frontend/src/tests/api/admin/admin_users.test.ts
+++ b/frontend/src/tests/api/admin/admin_users.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/admin/users/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+const createResponse = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('GET /api/admin/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeRequest = (token = 'test-token'): NextRequest =>
+    new NextRequest('http://localhost/api/admin/users', {
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    });
+
+  test('returns 401 when token is missing', async () => {
+    const req = makeRequest('');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({
+      ok: false,
+      error: 'Mangler token',
+    });
+  });
+
+  test('returns 403 when user is not superuser', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'user-1',
+      role: 'admin',
+      isAdmin: true,
+      isSuperuser: false,
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({
+      ok: false,
+      error: 'Ikke tilgang',
+    });
+  });
+
+  test('returns empty list when no users exist', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([], 200) as unknown as Response);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      data: [],
+    });
+  });
+
+  test('returns users list successfully', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    const users = [
+      { user_id: '1', name: 'A', email: 'a@test.com', role: 'admin' },
+      { user_id: '2', name: 'B', email: 'b@test.com', role: 'regular' },
+    ];
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createResponse(users, 200) as unknown as Response
+    );
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      data: users,
+    });
+  });
+
+  test('returns 500 when Supabase request fails', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: 'db error' }),
+    } as Response);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Kunne ikke hente brukere');
+  });
+
+  test('returns 500 when fetch throws', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('network error'));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+  });
+});

--- a/frontend/src/tests/api/admin/users_role.test.ts
+++ b/frontend/src/tests/api/admin/users_role.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PATCH } from '@/app/api/admin/users/role/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+const createResponse = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('PATCH /api/admin/users/role', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeRequest = (body?: unknown, token = 'test-token'): NextRequest =>
+    new NextRequest('http://localhost/api/admin/users/role', {
+      method: 'PATCH',
+      headers: token
+        ? {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/json',
+          }
+        : {
+            'content-type': 'application/json',
+          },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+  test('returns 401 when token is missing', async () => {
+    const req = makeRequest({ targetUserId: 'u1', role: 'admin' }, '');
+
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({
+      ok: false,
+      error: 'Mangler token',
+    });
+  });
+
+  test('returns 403 when requester is not superuser', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'admin-1',
+      role: 'admin',
+      isAdmin: true,
+      isSuperuser: false,
+    });
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Ikke tilgang');
+  });
+
+  test('returns 400 when targetUserId missing', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    const res = await PATCH(makeRequest({ role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Mangler bruker-ID');
+  });
+
+  test('returns 400 when role is invalid', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'superuser' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Ugyldig rolle');
+  });
+
+  test('returns 400 when changing own role', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    const res = await PATCH(makeRequest({ targetUserId: 'super-1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Du kan ikke endre din egen rolle her');
+  });
+
+  test('returns 404 when target user does not exist', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([], 200));
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Fant ikke bruker');
+  });
+
+  test('returns 403 when target user is superuser', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createResponse([{ user_id: 'u1', role: 'superuser' }], 200)
+    );
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Superuser kan ikke endres her');
+  });
+
+  test('updates role successfully', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createResponse([{ user_id: 'u1', role: 'regular' }], 200))
+      .mockResolvedValueOnce(createResponse([{ user_id: 'u1', role: 'admin' }], 200));
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      data: {
+        user_id: 'u1',
+        role: 'admin',
+      },
+    });
+  });
+
+  test('returns 500 when target lookup fails', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createResponse([{ user_id: 'super-1', role: 'superuser' }], 500)
+    );
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Kunne ikke hente målbruker');
+  });
+
+  test('returns 500 when update fails', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      userId: 'super-1',
+      role: 'superuser',
+      isAdmin: true,
+      isSuperuser: true,
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createResponse([{ user_id: 'u1', role: 'regular' }], 200))
+      .mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+    const res = await PATCH(makeRequest({ targetUserId: 'u1', role: 'admin' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Kunne ikke oppdatere rolle');
+  });
+});

--- a/frontend/src/tests/api/playlists/playlist_id.test.ts
+++ b/frontend/src/tests/api/playlists/playlist_id.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET, PATCH, DELETE } from '@/app/api/playlists/[id]/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+const createResponse = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('playlist/[id] route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeReq = (body?: unknown): Request =>
+    new Request('http://localhost', {
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+  const params = { params: Promise.resolve({ id: 'p1' }) };
+
+  describe('GET', () => {
+    test('returns playlist detail', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        createResponse([{ id: 'p1', title: 'Test' }], 200)
+      );
+
+      const res = await GET(new Request('http://localhost'), params);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        ok: true,
+        data: { id: 'p1', title: 'Test' },
+      });
+    });
+
+    test('returns 500 when supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const res = await GET(new Request('http://localhost'), params);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('PATCH', () => {
+    test('admin update path', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          title: 'new title',
+          is_public: true,
+        }),
+      });
+
+      const res = await PATCH(req, params);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('non-admin update path', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = makeReq({
+        title: 'title',
+        password: '1234',
+        is_public: false,
+      });
+
+      const res = await PATCH(req, params);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('returns 500 on RPC failure', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ error: 'fail' }, 500));
+
+      const req = makeReq({ title: 'x' });
+
+      const res = await PATCH(req, params);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('DELETE', () => {
+    test('admin delete', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({}),
+      });
+
+      const res = await DELETE(req, params);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('user delete with password', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({ password: '1234' }),
+      });
+
+      const res = await DELETE(req, params);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+  });
+});

--- a/frontend/src/tests/api/playlists/playlist_items.test.ts
+++ b/frontend/src/tests/api/playlists/playlist_items.test.ts
@@ -1,0 +1,176 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET, POST, DELETE } from '@/app/api/playlist_items/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('playlist-items API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET playlist-items', () => {
+    test('returns data successfully', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'song' }], 200));
+
+      const req = new Request('http://localhost/api?playlist_id=abc&limit=10');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        ok: true,
+        data: [{ id: 1, name: 'song' }],
+      });
+    });
+
+    test('returns 500 when Supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+  describe('POST playlist-items', () => {
+    test('calls admin RPC when user is admin', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          playlist_id: 'p1',
+          song_id: 's1',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('calls normal RPC when not admin', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          playlist_id: 'p1',
+          song_id: 's1',
+          password: '1234',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('returns 500 on RPC failure', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ error: 'fail' }, 500));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          playlist_id: 'p1',
+          song_id: 's1',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('DELETE playlist-items', () => {
+    test('removes item successfully (admin)', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ success: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          playlist_id: 'p1',
+          song_id: 's1',
+        }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('returns 500 when delete fails', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ error: 'fail' }, 500));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          playlist_id: 'p1',
+          song_id: 's1',
+          password: '1234',
+        }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/api/playlists/playlist_verify.test.ts
+++ b/frontend/src/tests/api/playlists/playlist_verify.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { POST } from '@/app/api/playlists/verify/route';
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST verify password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+  });
+
+  test('returns success', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ valid: true }], 200));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        playlist_id: 'p1',
+        password: '1234',
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+
+  test('returns error when supabase fails', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 400));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        playlist_id: 'p1',
+        password: '1234',
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+  });
+
+  test('returns 500 on crash', async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('fail'));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        playlist_id: 'p1',
+        password: '1234',
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Server error');
+  });
+});

--- a/frontend/src/tests/api/playlists/playlists.test.ts
+++ b/frontend/src/tests/api/playlists/playlists.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET, POST } from '@/app/api/playlists/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('playlists API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------
+  // GET
+  // -------------------------
+  describe('GET playlists', () => {
+    test('returns list when no id is provided', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, title: 'A' }], 200));
+
+      const req = new Request('http://localhost/api/playlists');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual([{ id: 1, title: 'A' }]);
+    });
+
+    test('returns playlist detail when id is provided', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        createResponse({ id: 1, title: 'Detail' }, 200)
+      );
+
+      const req = new Request('http://localhost/api/playlists?id=123');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('returns 500 on supabase error', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api/playlists');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  // -------------------------
+  // POST
+  // -------------------------
+  describe('POST playlists', () => {
+    test('create playlist', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ id: 1 }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: JSON.stringify({
+          action: 'create',
+          title: 'hello',
+          password: '123',
+          is_public: true,
+          expires_at: null,
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('add item as non-admin', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ ok: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: JSON.stringify({
+          action: 'add_item',
+          playlist_id: 'p1',
+          song_id: 's1',
+          password: '123',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('remove item as admin', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: true,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ ok: true }, 200));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: JSON.stringify({
+          action: 'remove_item',
+          playlist_id: 'p1',
+          song_id: 's1',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    test('delete playlist fails', async () => {
+      vi.mocked(checkAdminAccess).mockResolvedValue({
+        isAdmin: false,
+      } as never);
+
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ error: 'fail' }, 500));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: JSON.stringify({
+          action: 'delete',
+          playlist_id: 'p1',
+          password: '123',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+
+    test('invalid action returns 400', async () => {
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'unknown',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid action');
+    });
+  });
+});

--- a/frontend/src/tests/api/playlists/songs_from_playlist.test.ts
+++ b/frontend/src/tests/api/playlists/songs_from_playlist.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { GET } from '../../../app/api/playlists/[id]/songs/route';
+import { GET } from '@/app/api/playlists/[id]/songs/route';
 
 vi.mock('@/src/lib/supabase/isAdmin', () => ({
   checkAdminAccess: vi.fn(),
@@ -10,7 +10,7 @@ describe('playlists [id] songs route', () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
 
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabasse.no';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.no';
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
   });
 

--- a/frontend/src/tests/api/songs/song_id.test.ts
+++ b/frontend/src/tests/api/songs/song_id.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { DELETE, GET, PATCH } from '../../../app/api/songs/[id]/route';
+import { DELETE, GET, PATCH } from '@/app/api/songs/[id]/route';
 import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
 
 vi.mock('@/src/lib/supabase/isAdmin', () => ({
@@ -36,9 +36,10 @@ describe('songs [id] route', () => {
     expect(body.data.id).toBe(songId);
   });
 
-  test('PATCH returns 403 when user is not admin', async () => {
+  test('PATCH returns 403 when user is not admin or superuser', async () => {
     vi.mocked(checkAdminAccess).mockResolvedValue({
       isAdmin: false,
+      isSuperuser: false,
       userId: null,
       role: null,
     });
@@ -63,6 +64,7 @@ describe('songs [id] route', () => {
   test('DELETE returns 404 when nothing is deleted', async () => {
     vi.mocked(checkAdminAccess).mockResolvedValue({
       isAdmin: true,
+      isSuperuser: false,
       userId: 'user-1',
       role: 'admin',
     });

--- a/frontend/src/tests/api/songs/song_suggestion.test.ts
+++ b/frontend/src/tests/api/songs/song_suggestion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { POST } from '../../../app/api/song_suggestions/route';
+import { POST } from '@/app/api/song_suggestions/route';
 
 describe('POST /api/song_suggestions', () => {
   beforeEach(() => {

--- a/frontend/src/tests/api/songs/song_tags.test.ts
+++ b/frontend/src/tests/api/songs/song_tags.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, DELETE } from '@/app/api/song_tags/route';
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('song_tags API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+  });
+
+  describe('GET', () => {
+    test('returns song tags', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, tag: 'rock' }], 200));
+
+      const req = new Request('http://localhost/api/song_tags?limit=10');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual([{ id: 1, tag: 'rock' }]);
+    });
+
+    test('returns error when supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api/song_tags');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('POST', () => {
+    test('creates song tag', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1 }], 201));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          song_id: 's1',
+          tag_id: 't1',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual([{ id: 1 }]);
+    });
+
+    test('returns 400 when missing fields', async () => {
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 500 when supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          song_id: 's1',
+          tag_id: 't1',
+        }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('DELETE', () => {
+    test('deletes song tag', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1 }], 200));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          song_id: 's1',
+          tag_id: 't1',
+        }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual({ id: 1 });
+    });
+
+    test('returns 404 when nothing deleted', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([], 200));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          song_id: 's1',
+          tag_id: 't1',
+        }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 400 when missing fields', async () => {
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({}),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 500 when supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost', {
+        method: 'DELETE',
+        body: JSON.stringify({
+          song_id: 's1',
+          tag_id: 't1',
+        }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/api/songs/songs.test.ts
+++ b/frontend/src/tests/api/songs/songs.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GET, POST } from '@/app/api/songs/route';
+import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
+
+vi.mock('@/src/lib/supabase/isAdmin', () => ({
+  checkAdminAccess: vi.fn(),
+}));
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('songs API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+    global.fetch = vi.fn();
+  });
+
+  test('GET returns songs list', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, title: 'Song' }], 200));
+
+    const req = new Request('http://localhost/api/songs?limit=10');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual([{ id: 1, title: 'Song' }]);
+  });
+
+  test('GET returns error when supabase fails', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+    const req = new Request('http://localhost/api/songs');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+  });
+
+  test('POST creates song as admin', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      isAdmin: true,
+    } as never);
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createResponse([{ id: 'song-1' }], 201)) // insert song
+      .mockResolvedValueOnce(createResponse([{ song_id: 'song-1' }], 201)); // song_tags
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: 'test song',
+        tags: ['a', 'b'],
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.destination).toBe('songs');
+  });
+
+  test('POST creates song suggestion when not admin', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      isAdmin: false,
+    } as never);
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 'suggest-1' }], 201));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: 'test song',
+        tags: [],
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.destination).toBe('song_suggestions');
+  });
+
+  test('POST returns 500 if insert returns empty array', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      isAdmin: true,
+    } as never);
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([], 200));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: 'test',
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+  });
+
+  test('POST returns error when supabase insert fails', async () => {
+    vi.mocked(checkAdminAccess).mockResolvedValue({
+      isAdmin: true,
+    } as never);
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: 'test',
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+  });
+});

--- a/frontend/src/tests/api/tags.test.ts
+++ b/frontend/src/tests/api/tags.test.ts
@@ -1,0 +1,199 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GET, POST, DELETE, PATCH } from '@/app/api/tags/route';
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('tags API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+    global.fetch = vi.fn();
+  });
+
+  describe('GET', () => {
+    test('returns tags list', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'rock' }], 200));
+
+      const req = new Request('http://localhost/api/tags?limit=10');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual([{ id: 1, name: 'rock' }]);
+    });
+
+    test('returns error when supabase fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api/tags');
+
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('POST', () => {
+    test('creates tag successfully', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'rock' }], 201));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'rock' }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual([{ id: 1, name: 'rock' }]);
+    });
+
+    test('returns 400 when name missing', async () => {
+      const req = new Request('http://localhost/api/tags', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 500 when insert fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'rock' }),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('DELETE', () => {
+    test('deletes tag successfully', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'rock' }], 200));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'DELETE',
+        body: JSON.stringify({ id: 1 }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual({ id: 1, name: 'rock' });
+    });
+
+    test('returns 404 when nothing deleted', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([], 200));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'DELETE',
+        body: JSON.stringify({ id: 1 }),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 400 when id missing', async () => {
+      const req = new Request('http://localhost/api/tags', {
+        method: 'DELETE',
+        body: JSON.stringify({}),
+      });
+
+      const res = await DELETE(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+  });
+
+  describe('PATCH', () => {
+    test('updates tag successfully', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'jazz' }], 200));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'PATCH',
+        body: JSON.stringify({ id: 1, name: 'jazz' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual({ id: 1, name: 'jazz' });
+    });
+
+    test('returns 400 when id missing', async () => {
+      const req = new Request('http://localhost/api/tags', {
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'jazz' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 400 when name missing', async () => {
+      const req = new Request('http://localhost/api/tags', {
+        method: 'PATCH',
+        body: JSON.stringify({ id: 1 }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+    });
+
+    test('returns 500 when update fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+      const req = new Request('http://localhost/api/tags', {
+        method: 'PATCH',
+        body: JSON.stringify({ id: 1, name: 'jazz' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/api/users/users.test.ts
+++ b/frontend/src/tests/api/users/users.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { GET } from '@/app/api/users/route';
+
+function createResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('GET /api/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'anon-key';
+
+    global.fetch = vi.fn();
+  });
+
+  test('returns users list successfully', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1, name: 'Alice' }], 200));
+
+    const req = new Request('http://localhost/api/users?limit=10');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      data: [{ id: 1, name: 'Alice' }],
+    });
+  });
+
+  test('returns 500 when env variables are missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const req = new Request('http://localhost/api/users');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Missing Supabase env variables');
+  });
+
+  test('returns error when supabase fails', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse({ message: 'db error' }, 500));
+
+    const req = new Request('http://localhost/api/users');
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+  });
+
+  test('respects limit query param', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(createResponse([{ id: 1 }], 200));
+
+    const req = new Request('http://localhost/api/users?limit=5');
+
+    await GET(req);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const calledUrl = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('limit=5');
+  });
+});

--- a/frontend/src/tests/api/users/users_me.test.ts
+++ b/frontend/src/tests/api/users/users_me.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { GET } from '../../../app/api/users/me/route';
+import { GET } from '@/app/api/users/me/route';
 import { checkAdminAccess } from '@/src/lib/supabase/isAdmin';
 
 vi.mock('@/src/lib/supabase/isAdmin', () => ({


### PR DESCRIPTION
### What's done
- Updated existing api tests
- Implemented tests for all other api endpoints/routes
- Removed body from returning when error of users happens to prevent data from leaking

### How to test
- Ensure all tests run through