### PR TITLE
fix: stop campfire audio on unmount

### DIFF
--- a/frontend/src/hooks/useCampfire.ts
+++ b/frontend/src/hooks/useCampfire.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export function useCampfire() {
   const [boost, setBoost] = useState(false);
@@ -58,6 +58,13 @@ export function useCampfire() {
       start();
     }
   }
+
+  // Cleans up audio: stops audio on umount (route change)
+  useEffect(() => {
+    return () => {
+      stop();
+    };
+  }, []);
 
   return {
     boost,


### PR DESCRIPTION
 Add cleanup useEffect to stop campfire audio on unmount

**Whats done**:
- Added a useEffect in useCampfire hook which stops the audio when the component is unmounted. So when the user redirects or navigates away from the campfire, the audio will stop.

**How to test**:
- Navigate to any invalid page (not-found) or the campfire page from /settings. Start the campfire and hear the audio. Navigate away from the page after audio has started, and verify the audio stops playing when you enter a new page.