### PR TITLE
fix: changed the export-button name to norwegian

### DIFF
--- a/frontend/src/components/admin/AdminContent.tsx
+++ b/frontend/src/components/admin/AdminContent.tsx
@@ -124,7 +124,7 @@ export default function AdminContent() {
             onClick={() => setOpen(true)}
             className="text-md cursor-pointer"
           >
-            Export
+            Eksporter
           </Button>
 
           <ExportLatexModal


### PR DESCRIPTION
**What's done**:
- By accident, the button for user to export songs to latex was named in english. Now it is norwegian.