### PR TITLE
Persist state in wakelocktoggle in localstorage

### DIFF
--- a/frontend/src/components/songs/WakeLockToggle.tsx
+++ b/frontend/src/components/songs/WakeLockToggle.tsx
@@ -1,12 +1,27 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { useWakeLock } from '@/src/hooks/useWakeLock';
+import ls from 'localstorage-slim';
+
+// key used to persist the toggle state in local storage
+const WAKE_LOCK_KEY = 'wakeLockEnabled';
 
 export default function WakeLockToggle() {
-  const [enabled, setEnabled] = useState(false);
+  // initialize state from localStorage (client-side only)
+  // if nothing is stored yet, default to false (opt-out)
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return !!ls.get(WAKE_LOCK_KEY);
+  });
 
+  // persist state on change - toggle survives navigation and reloads
+  useEffect(() => {
+    ls.set(WAKE_LOCK_KEY, enabled);
+  }, [enabled]);
+
+  // activate wakeLock based on state
   useWakeLock(enabled);
 
   // hide toggle if wake lock API is not supported on that browser

--- a/frontend/src/hooks/usePWAInstall.ts
+++ b/frontend/src/hooks/usePWAInstall.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import ls from 'localstorage-slim';
 
+// Keys used to persist state in local storage
 const DISMISSED_KEY = 'pwaBannerDismissed';
 const DISMISSED_TTL = 7 * 24 * 60 * 60; // 7 days
 


### PR DESCRIPTION
**Whats done**:
- Added localstorage-slim to wakelocktoggle, so that the state persists here. To fix bug where it only was set in state in compnent and therefore reset on navigation.

**How to test**:
- Go to /settings and enable WakeLockToggle
- Navigate away from settings and back again, and verify that the state persists (it's still enabled)
- View the wakelock key in localstorage in dev mode, and verify that changing it from true or false changes the state in the app (you may need to refresh)